### PR TITLE
Add needs_review filter to get_transactions

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1445,6 +1445,7 @@ class MonarchMoney(object):
         is_recurring: Optional[bool] = None,
         imported_from_mint: Optional[bool] = None,
         synced_from_institution: Optional[bool] = None,
+        needs_review: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.
@@ -1464,6 +1465,7 @@ class MonarchMoney(object):
         :param is_recurring: a bool to filter for whether the transactions are recurring.
         :param imported_from_mint: a bool to filter for whether the transactions were imported from mint.
         :param synced_from_institution: a bool to filter for whether the transactions were synced from an institution.
+        :param needs_review: a bool to filter for whether the transactions need review.
         """
 
         query = gql(
@@ -1568,6 +1570,9 @@ class MonarchMoney(object):
 
         if synced_from_institution is not None:
             variables["filters"]["syncedFromInstitution"] = synced_from_institution
+
+        if needs_review is not None:
+            variables["filters"]["needsReview"] = needs_review
 
         if start_date and end_date:
             variables["filters"]["startDate"] = start_date

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -237,6 +237,26 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
                 email="", password="", use_saved_session=False
             )
 
+    @patch.object(Client, "execute_async")
+    async def test_get_transactions_needs_review_filter(self, mock_execute_async):
+        """
+        Test that needs_review parameter is passed as needsReview in GraphQL filters.
+        """
+        mock_execute_async.return_value = {
+            "allTransactions": {"results": [], "totalCount": 0},
+            "transactionRules": [],
+        }
+
+        await self.monarch_money.get_transactions(needs_review=True)
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertIn("variable_values", kwargs)
+        self.assertTrue(
+            kwargs["variable_values"]["filters"]["needsReview"],
+            "Expected needsReview filter to be True",
+        )
+
     @patch("builtins.input", return_value="")
     @patch("getpass.getpass", return_value="")
     async def test_interactive_login(self, _input_mock, _getpass_mock):


### PR DESCRIPTION
## Summary

- Adds `needs_review: Optional[bool]` parameter to `get_transactions()`
- Wires it to the `needsReview` field in the GraphQL `TransactionFilterInput`
- Mirrors the same field already used in `update_transaction()`

## Test plan

- [ ] `get_transactions(needs_review=True)` returns only transactions pending review
- [ ] `get_transactions(needs_review=False)` returns only reviewed transactions
- [ ] Omitting the parameter returns all transactions (existing behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)