### PR TITLE
feat: add flex budget management (update amount, reset rollover, reset month)

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2722,6 +2722,105 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
+    async def update_flex_rollover_settings(
+        self,
+        rollover_start_month: Optional[str] = None,
+        rollover_starting_balance: float = 0.0,
+        rollover_enabled: bool = True,
+        budget_system: str = "fixed_and_flex",
+    ) -> Dict[str, Any]:
+        """
+        Updates the Flex bucket rollover settings. Can be used to reset accumulated
+        rollover by pointing the start month to the current (or desired) month with
+        a starting balance of 0.
+
+        This resolves the common "Flex bucket has huge negative rollover" problem
+        where over-budget months accumulate for months or years. Resetting the
+        period creates a fresh rollover period starting from the given month.
+
+        :param rollover_start_month:
+            ISO date string for the new rollover period start (ex: "2026-04-01").
+            Defaults to start of current month.
+        :param rollover_starting_balance:
+            Balance to seed the new rollover period with. Default 0.0 (a fresh start).
+        :param rollover_enabled:
+            Whether flex rollover is enabled. Default True.
+        :param budget_system:
+            Budget system identifier. Default "fixed_and_flex".
+
+        Example (reset flex rollover to $0 starting this month):
+            await mm.update_flex_rollover_settings()
+        """
+        query = gql(
+            """
+            mutation Web_UpdateFlexibleGroupRolloverSettings($input: UpdateBudgetSettingsMutationInput!) {
+              updateBudgetSettings(input: $input) {
+                budgetRolloverPeriod {
+                  id
+                  startMonth
+                  startingBalance
+                  __typename
+                }
+                __typename
+              }
+            }
+            """
+        )
+
+        variables = {
+            "input": {
+                "rolloverEnabled": rollover_enabled,
+                "rolloverStartMonth": rollover_start_month or self._get_start_of_current_month(),
+                "rolloverStartingBalance": rollover_starting_balance,
+                "budgetSystem": budget_system,
+            }
+        }
+
+        return await self.gql_call(
+            operation="Web_UpdateFlexibleGroupRolloverSettings",
+            variables=variables,
+            graphql_query=query,
+        )
+
+    async def reset_budget(
+        self,
+        start_date: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Resets the budget for a specific month. Clears planned amounts back to
+        defaults/zero for the given month.
+
+        :param start_date:
+            The beginning of the month to reset (ex: "2026-04-01"). Defaults to
+            start of current month.
+        """
+        query = gql(
+            """
+            mutation Common_ResetBudget($input: ResetBudgetMutationInput!) {
+              resetBudget(input: $input) {
+                errors {
+                  message
+                  code
+                  __typename
+                }
+                __typename
+              }
+            }
+            """
+        )
+
+        variables = {
+            "input": {
+                "startDate": start_date or self._get_start_of_current_month(),
+            }
+        }
+
+        return await self.gql_call(
+            operation="Common_ResetBudget",
+            variables=variables,
+            graphql_query=query,
+        )
+
     async def upload_account_balance_history(
         self,
         account_id: str,

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2672,6 +2672,56 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
+    async def update_flexible_budget(
+        self,
+        amount: float,
+        start_date: Optional[str] = None,
+        apply_to_future: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Updates the Flexible budget amount.
+
+        This is the bucket-level budget for the "fixed_and_flex" budget system.
+        Unlike set_budget_amount() which targets a specific category, this method
+        sets the total Flex bucket allowance for a month.
+
+        :param amount:
+            The amount to set the Flexible budget to. A zero value will unset it.
+        :param start_date:
+            The beginning of the target month (ex: 2026-04-01). Defaults to the
+            start of the current month.
+        :param apply_to_future:
+            Whether to apply the new budget amount to all subsequent months.
+        """
+        query = gql(
+            """
+            mutation Common_UpdateFlexBudgetMutation($input: UpdateOrCreateFlexBudgetItemMutationInput!) {
+              updateOrCreateFlexBudgetItem(input: $input) {
+                budgetItem {
+                  id
+                  budgetAmount
+                  __typename
+                }
+                __typename
+              }
+            }
+            """
+        )
+
+        variables = {
+            "input": {
+                "startDate": start_date or self._get_start_of_current_month(),
+                "amount": amount,
+                "applyToFuture": apply_to_future,
+            }
+        }
+
+        return await self.gql_call(
+            operation="Common_UpdateFlexBudgetMutation",
+            variables=variables,
+            graphql_query=query,
+        )
+
     async def upload_account_balance_history(
         self,
         account_id: str,


### PR DESCRIPTION
## Summary

Adds three new methods for managing the "fixed_and_flex" budget system in Monarch Money, filling gaps where the existing `set_budget_amount()` only handles per-category fixed budgets.

## New methods

### `update_flexible_budget(amount, start_date=None, apply_to_future=False)`

Sets the Flex bucket budget amount for a given month. Uses the `Common_UpdateFlexBudgetMutation` GraphQL mutation (`updateOrCreateFlexBudgetItem`).

Ported from upstream PR hammem/monarchmoney#154 (closed, unmerged).

### `update_flex_rollover_settings(rollover_start_month=None, rollover_starting_balance=0.0, rollover_enabled=True, budget_system="fixed_and_flex")`

**Resolves the common "my Flex bucket has -$XX,XXX accumulated rollover" problem.**

When the Flex bucket rollover has been running for months/years, over-budget amounts accumulate into a large negative number that the UI shows as a persistent deficit. This method resets the rollover period — creating a new period with a fresh start month and balance.

Calls `Web_UpdateFlexibleGroupRolloverSettings` → `updateBudgetSettings` mutation with `UpdateBudgetSettingsMutationInput`. Mutation name and input shape were reverse-engineered from Monarch's web app JavaScript bundle since they aren't in any public library.

### `reset_budget(start_date=None)`

Resets a specific month's planned budget amounts back to defaults. Calls `Common_ResetBudget` / `resetBudget` mutation.

## Testing

All three methods tested against a live Monarch Money account:

- `update_flexible_budget(amount=4000, start_date='2026-04-01')` → returned BudgetItem ID
- `update_flex_rollover_settings()` → cleared 14 months of accumulated rollover (-$270k → $0), created new period `240806279431422152` with startMonth 2026-04-01
- `reset_budget(start_date='2026-04-01')` → errors: null, successful

## Related

- Upstream issue: hammem/monarchmoney#119 (Flex budgets unsupported)
- Upstream PR: hammem/monarchmoney#154 (closed, unmerged)

## Test plan

- [x] Methods compile
- [x] All three methods execute successfully against live Monarch account
- [x] Verified rollover period state changes correctly
- [ ] Unit tests (no existing pattern for mocked GraphQL mutations in this repo)