### PR TITLE
feat: add find_duplicate_transactions() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,46 +117,181 @@ As of writing this README, the following methods are supported:
 
 ## Non-Mutating Methods
 
-- `get_accounts` - gets all the accounts linked to Monarch Money
-- `get_account_holdings` - gets all of the securities in a brokerage or similar type of account
-- `get_account_type_options` - all account types and their subtypes available in Monarch Money
-- `get_account_history` - gets all daily account history for the specified account
-- `get_institutions` - gets institutions linked to Monarch Money
-- `get_budgets` - all the budgets and the corresponding actual amounts
-- `get_credit_history` - gets credit score snapshots and Spinwheel user details
-- `get_subscription_details` - gets the Monarch Money account's status (e.g. paid or trial)
-- `get_recurring_transactions` - gets the future recurring transactions, including merchant and account details
-- `get_transactions_summary` - gets the transaction summary data from the transactions page
-- `get_transactions` - gets transaction data, defaults to returning the last 100 transactions; can also be searched by date range
-- `get_transaction_categories` - gets all of the categories configured in the account
-- `get_transaction_category_groups` - all category groups configured in the account
-- `get_transaction_details` - gets detailed transaction data for a single transaction
-- `get_transaction_splits` - gets transaction splits for a single transaction
-- `get_transaction_tags` - gets all of the tags configured in the account
-- `get_cashflow` - gets cashflow data (by category, category group, merchant and a summary)
-- `get_cashflow_summary` - gets cashflow summary (income, expense, savings, savings rate)
-- `is_accounts_refresh_complete` - gets the status of a running account refresh
+<table>
+  <thead>
+    <tr>
+      <th width="280">Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>get_accounts</code></td>
+      <td>gets all the accounts linked to Monarch Money</td>
+    </tr>
+    <tr>
+      <td><code>get_account_holdings</code></td>
+      <td>gets all of the securities in a brokerage or similar type of account</td>
+    </tr>
+    <tr>
+      <td><code>get_account_type_options</code></td>
+      <td>all account types and their subtypes available in Monarch Money</td>
+    </tr>
+    <tr>
+      <td><code>get_account_history</code></td>
+      <td>gets all daily account history for the specified account</td>
+    </tr>
+    <tr>
+      <td><code>get_institutions</code></td>
+      <td>gets institutions linked to Monarch Money</td>
+    </tr>
+    <tr>
+      <td><code>get_budgets</code></td>
+      <td>all the budgets and the corresponding actual amounts</td>
+    </tr>
+    <tr>
+      <td><code>get_credit_history</code></td>
+      <td>gets credit score snapshots and Spinwheel user details</td>
+    </tr>
+    <tr>
+      <td><code>get_subscription_details</code></td>
+      <td>gets the Monarch Money account's status (e.g. paid or trial)</td>
+    </tr>
+    <tr>
+      <td><code>get_recurring_transactions</code></td>
+      <td>gets the future recurring transactions, including merchant and account details</td>
+    </tr>
+    <tr>
+      <td><code>get_transactions_summary</code></td>
+      <td>gets the transaction summary data from the transactions page</td>
+    </tr>
+    <tr>
+      <td><code>get_transactions</code></td>
+      <td>gets transaction data, defaults to returning the last 100 transactions; can also be searched by date range</td>
+    </tr>
+    <tr>
+      <td><code>find_duplicate_transactions</code></td>
+      <td>finds duplicate transaction groups using Plaid-reported fields</td>
+    </tr>
+    <tr>
+      <td><code>get_transaction_categories</code></td>
+      <td>gets all of the categories configured in the account</td>
+    </tr>
+    <tr>
+      <td><code>get_transaction_category_groups</code></td>
+      <td>all category groups configured in the account</td>
+    </tr>
+    <tr>
+      <td><code>get_transaction_details</code></td>
+      <td>gets detailed transaction data for a single transaction</td>
+    </tr>
+    <tr>
+      <td><code>get_transaction_splits</code></td>
+      <td>gets transaction splits for a single transaction</td>
+    </tr>
+    <tr>
+      <td><code>get_transaction_tags</code></td>
+      <td>gets all of the tags configured in the account</td>
+    </tr>
+    <tr>
+      <td><code>get_cashflow</code></td>
+      <td>gets cashflow data (by category, category group, merchant and a summary)</td>
+    </tr>
+    <tr>
+      <td><code>get_cashflow_summary</code></td>
+      <td>gets cashflow summary (income, expense, savings, savings rate)</td>
+    </tr>
+    <tr>
+      <td><code>is_accounts_refresh_complete</code></td>
+      <td>gets the status of a running account refresh</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Mutating Methods
 
-- `delete_transaction_category` - deletes a category for transactions
-- `delete_transaction_categories` - deletes a list of transaction categories for transactions
-- `create_transaction_category` - creates a category for transactions
-- `request_accounts_refresh` - requests a synchronization / refresh of all accounts linked to Monarch Money. This is a **non-blocking call**. If the user wants to check on the status afterwards, they must call `is_accounts_refresh_complete`.
-- `request_accounts_refresh_and_wait` - requests a synchronization / refresh of all accounts linked to Monarch Money. This is a **blocking call** and will not return until the refresh is complete or no longer running.
-- `create_transaction` - creates a transaction with the given attributes
-- `update_transaction` - modifies one or more attributes for an existing transaction
-- `update_reoccuring` - updates recurring merchant settings (frequency, amount, date, active status)
-- `delete_transaction` - deletes a given transaction by the provided transaction id
-- `update_transaction_splits` - modifies how a transaction is split (or not)
-- `create_transaction_tag` - creates a tag for transactions
-- `set_transaction_tags` - sets the tags on a transaction
-- `set_budget_amount` - sets a budget's value to the given amount (date allowed, will only apply to month specified by default). A zero amount value will `unset` or `clear` the budget for the given category.
-- `create_manual_account` - creates a new manual account
-- `delete_account` - deletes an account by the provided account id
-- `update_account` - updates settings and/or balance of the provided account id
-- `upload_account_balance_history` - uploads account history csv file for a given account
-- `upload_attachment` - uploads a binary file for a given transaction by the provided transaction id
+<table>
+  <thead>
+    <tr>
+      <th width="280">Method</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>delete_transaction_category</code></td>
+      <td>deletes a category for transactions</td>
+    </tr>
+    <tr>
+      <td><code>delete_transaction_categories</code></td>
+      <td>deletes a list of transaction categories for transactions</td>
+    </tr>
+    <tr>
+      <td><code>create_transaction_category</code></td>
+      <td>creates a category for transactions</td>
+    </tr>
+    <tr>
+      <td><code>request_accounts_refresh</code></td>
+      <td>requests a synchronization / refresh of all accounts linked to Monarch Money. This is a <strong>non-blocking call</strong>. If the user wants to check on the status afterwards, they must call <code>is_accounts_refresh_complete</code>.</td>
+    </tr>
+    <tr>
+      <td><code>request_accounts_refresh_and_wait</code></td>
+      <td>requests a synchronization / refresh of all accounts linked to Monarch Money. This is a <strong>blocking call</strong> and will not return until the refresh is complete or no longer running.</td>
+    </tr>
+    <tr>
+      <td><code>create_transaction</code></td>
+      <td>creates a transaction with the given attributes</td>
+    </tr>
+    <tr>
+      <td><code>update_transaction</code></td>
+      <td>modifies one or more attributes for an existing transaction</td>
+    </tr>
+    <tr>
+      <td><code>update_reoccuring</code></td>
+      <td>updates recurring merchant settings (frequency, amount, date, active status)</td>
+    </tr>
+    <tr>
+      <td><code>delete_transaction</code></td>
+      <td>deletes a given transaction by the provided transaction id</td>
+    </tr>
+    <tr>
+      <td><code>update_transaction_splits</code></td>
+      <td>modifies how a transaction is split (or not)</td>
+    </tr>
+    <tr>
+      <td><code>create_transaction_tag</code></td>
+      <td>creates a tag for transactions</td>
+    </tr>
+    <tr>
+      <td><code>set_transaction_tags</code></td>
+      <td>sets the tags on a transaction</td>
+    </tr>
+    <tr>
+      <td><code>set_budget_amount</code></td>
+      <td>sets a budget's value to the given amount (date allowed, will only apply to month specified by default). A zero amount value will <code>unset</code> or <code>clear</code> the budget for the given category.</td>
+    </tr>
+    <tr>
+      <td><code>create_manual_account</code></td>
+      <td>creates a new manual account</td>
+    </tr>
+    <tr>
+      <td><code>delete_account</code></td>
+      <td>deletes an account by the provided account id</td>
+    </tr>
+    <tr>
+      <td><code>update_account</code></td>
+      <td>updates settings and/or balance of the provided account id</td>
+    </tr>
+    <tr>
+      <td><code>upload_account_balance_history</code></td>
+      <td>uploads account history csv file for a given account</td>
+    </tr>
+    <tr>
+      <td><code>upload_attachment</code></td>
+      <td>uploads a binary file for a given transaction by the provided transaction id</td>
+    </tr>
+  </tbody>
+</table>
 
 # Contributing
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2672,6 +2672,110 @@ class MonarchMoney(object):
             graphql_query=query,
         )
 
+    async def find_duplicate_transactions(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        account_ids: Optional[List[str]] = None,
+        page_size: int = 500,
+    ) -> List[Dict[str, Any]]:
+        """
+        Finds groups of duplicate transactions using the Plaid-reported fields.
+
+        Two transactions are considered duplicates when they share the SAME:
+          - date
+          - amount
+          - plaidName (Plaid's raw transaction description / reference string)
+          - account id
+
+        This is the correct dedup key because ``plaidName`` carries Plaid's
+        per-event reference. Two legitimate same-day, same-merchant, same-amount
+        charges (e.g. two separate Alaska Airlines seat fees) will carry
+        DIFFERENT reference numbers inside ``plaidName`` and will not be grouped.
+        Only rows that Plaid / Monarch wrote twice from a single upstream event
+        share an identical ``plaidName`` string.
+
+        Common causes of duplicates this method catches:
+          - Re-linking an Apple Card / Apple Cash / Apple Savings account (Monarch
+            re-inserts the full historical range as new rows — a known issue
+            documented in Monarch's own help center).
+          - Institution re-authentications after credential changes.
+          - Plaid write retries (microsecond-spaced sequential IDs).
+
+        :param start_date: Optional ISO date lower bound (inclusive).
+        :param end_date: Optional ISO date upper bound (inclusive).
+        :param account_ids: Optional account-id filter.
+        :param page_size: Pagination size when walking ``get_transactions``.
+
+        :returns: A list of duplicate groups. Each group is a dict of the form::
+
+            {
+                "date": "2025-09-19",
+                "amount": -54.03,
+                "plaidName": "Apple",
+                "account_id": "203496913710973596",
+                "account_name": "Apple Card",
+                "transactions": [<txn dict>, <txn dict>, ...],
+            }
+
+            The ``transactions`` list is sorted oldest-first by ``createdAt``, so
+            callers wanting to keep the original and delete the re-inserted copies
+            can simply retain ``transactions[0]`` and pass the rest to
+            :meth:`delete_transaction`.
+        """
+        all_txns: List[Dict[str, Any]] = []
+        offset = 0
+        while True:
+            result = await self.get_transactions(
+                limit=page_size,
+                offset=offset,
+                start_date=start_date,
+                end_date=end_date,
+                account_ids=account_ids or [],
+            )
+            batch = result.get("allTransactions", {}).get("results", []) or []
+            if not batch:
+                break
+            all_txns.extend(batch)
+            total = result.get("allTransactions", {}).get("totalCount") or 0
+            if len(all_txns) >= total:
+                break
+            offset += page_size
+
+        groups: Dict[tuple, List[Dict[str, Any]]] = {}
+        for t in all_txns:
+            plaid_name = (t.get("plaidName") or "").strip()
+            if not plaid_name:
+                continue
+            account = t.get("account") or {}
+            key = (
+                t.get("date"),
+                t.get("amount"),
+                plaid_name,
+                account.get("id"),
+            )
+            groups.setdefault(key, []).append(t)
+
+        duplicates: List[Dict[str, Any]] = []
+        for key, txns in groups.items():
+            if len(txns) < 2:
+                continue
+            txns_sorted = sorted(txns, key=lambda x: x.get("createdAt") or "")
+            duplicates.append(
+                {
+                    "date": key[0],
+                    "amount": key[1],
+                    "plaidName": key[2],
+                    "account_id": key[3],
+                    "account_name": (txns_sorted[0].get("account") or {}).get(
+                        "displayName"
+                    ),
+                    "transactions": txns_sorted,
+                }
+            )
+
+        return duplicates
+
     async def upload_account_balance_history(
         self,
         account_id: str,


### PR DESCRIPTION
Adds a `find_duplicate_transactions()` helper that returns groups of duplicate transactions using Plaid-reported fields.

## Why

Monarch Money has a **documented bug** where re-linking an Apple Card / Apple Cash / Apple Savings account (or other Plaid-backed institutions) re-inserts the full historical transaction range as new rows. Monarch's own help center acknowledges it:
- [Troubleshooting Duplicate Transactions](https://help.monarch.com/hc/en-us/articles/32110313427604)
- [Troubleshooting your Apple Card accounts](https://help.monarch.com/hc/en-us/articles/25195805450772)

The only official remediation is manual bulk-delete via the web UI's "edit multiple" feature. There is no programmatic dedup helper — users with hundreds or thousands of duplicate rows (very common after an iPhone upgrade triggers an Apple re-link) have to click through them by hand.

I hit this exact bug myself: **588 historical Apple Card/Cash transactions were re-inserted in a 12.5-second window**, with original dates spanning 2018-09-20 to 2025-09-20. This method is the proven dedup logic I used to identify and remove them via `delete_transaction()`.

## Dedup key

`(date, amount, plaidName, account_id)`

`plaidName` is the critical field. It carries Plaid's per-event reference string. Two **legitimate** same-day, same-merchant, same-amount charges (e.g. two separate Alaska Airlines seat fees on the same flight) carry **different** reference numbers inside `plaidName` — `"ALASKA AIR 0272134482399"` vs `"ALASKA AIR 0272134486575"` — and are correctly NOT grouped.

Only rows that Plaid/Monarch wrote twice from a single upstream event share an identical `plaidName`. This cleanly separates true duplicates from legitimate separate charges.

## Usage

```python
dups = await mm.find_duplicate_transactions()

for group in dups:
    print(f"{group['account_name']}: {len(group['transactions'])}x {group['plaidName']} on {group['date']}")
    # Keep the oldest, delete the rest
    for txn in group['transactions'][1:]:
        await mm.delete_transaction(transaction_id=txn['id'])
```

Supports optional `start_date`, `end_date`, `account_ids`, and `page_size` filters. Paginates `get_transactions` internally so it works on mailboxes with thousands of transactions.

## Testing

Smoke-tested against a live Monarch account with 4,889 post-dedup transactions — returns `0` groups (correct). Earlier in the same session, when 665 known duplicates were present, the same logic correctly identified every one of them and none of the legitimate same-merchant separate charges.

Passes `black --check`.

Related to the flex-budget PR trio (#22 #23 #24) — same personal-finance cleanup work that surfaced this bug.