### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Type Of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] GraphQL endpoint/query update
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Tests only
+
+## Required For New Features Or Endpoint Changes
+
+If this PR adds, updates, or fixes a Monarch feature or endpoint, include a sanitized Monarch response and DO NOT include real data. The PR will not be approved if a Monarch Response is not supplied.
+
+- [ ] I included a sanitized Monarch response/example
+- [ ] I removed or redacted any real personal or financial data
+
+## Explain your Change Below and how can it be reproduced in Monarch? (It will be tested locally before final merge)


### PR DESCRIPTION
- Now required for PR template to be filled.
- Most importantly, now required of feature changes to show a sanitized version showing the direct output of the new feature change request.
