### PR TITLE
Enable SSL certificate verification on GraphQL transport

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -3416,6 +3416,7 @@ class MonarchMoney(object):
             url=MonarchMoneyEndpoints.getGraphQL(),
             headers=self._headers,
             timeout=self._timeout,
+            ssl=True,
         )
         return Client(
             transport=transport,


### PR DESCRIPTION
## Summary
- Pass `ssl=True` to `AIOHTTPTransport` in `_get_graphql_client` so the GraphQL client validates the Monarch Money server certificate
- Silences the `UserWarning` that `gql`'s `AIOHTTPTransport` prints on every request (`"By default, AIOHTTPTransport does not verify ssl certificates"`)

## Why
`gql` currently defaults to *not* verifying SSL — unusual and insecure for a client talking to a financial API over the public internet. The warning itself is also noisy in any downstream tool (e.g. MCP servers) that surfaces library stderr. The upstream `gql` release notes say the default will flip in the next major version, but passing `ssl=True` explicitly makes the behavior correct today and documents intent.

## Test plan
- [ ] `python -m pytest` still passes
- [ ] A real call (e.g. `get_accounts`) succeeds without the `UserWarning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)