### PR TITLE
Add transaction_visibility filter to get_transactions

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -11,7 +11,7 @@ import time
 from dataclasses import dataclass
 from io import StringIO
 from datetime import datetime, date, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Literal
 
 import oathtool
 from aiohttp import ClientSession, FormData
@@ -1446,6 +1446,7 @@ class MonarchMoney(object):
         imported_from_mint: Optional[bool] = None,
         synced_from_institution: Optional[bool] = None,
         needs_review: Optional[bool] = None,
+        transaction_visibility: Optional[Literal["hidden_transactions_only","all_transactions"]] = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.
@@ -1466,6 +1467,10 @@ class MonarchMoney(object):
         :param imported_from_mint: a bool to filter for whether the transactions were imported from mint.
         :param synced_from_institution: a bool to filter for whether the transactions were synced from an institution.
         :param needs_review: a bool to filter for whether the transactions need review.
+        :param transaction_visibility: a string to set scope of transactions to return.
+          None (default) for only non-hidden transactions.
+          "hidden_transactions_only" for only hidden transactions.
+          "all_transactions" for hidden and non-hidden transactions.
         """
 
         query = gql(
@@ -1573,6 +1578,9 @@ class MonarchMoney(object):
 
         if needs_review is not None:
             variables["filters"]["needsReview"] = needs_review
+
+        if transaction_visibility is not None:
+            variables["filters"]["transactionVisibility"] = transaction_visibility
 
         if start_date and end_date:
             variables["filters"]["startDate"] = start_date

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1446,7 +1446,9 @@ class MonarchMoney(object):
         imported_from_mint: Optional[bool] = None,
         synced_from_institution: Optional[bool] = None,
         needs_review: Optional[bool] = None,
-        transaction_visibility: Optional[Literal["hidden_transactions_only","all_transactions"]] = None,
+        transaction_visibility: Optional[
+            Literal["hidden_transactions_only", "all_transactions"]
+        ] = None,
     ) -> Dict[str, Any]:
         """
         Gets transaction data from the account.

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -257,6 +257,27 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
             "Expected needsReview filter to be True",
         )
 
+    @patch.object(Client, "execute_async")
+    async def test_get_transactions_transaction_visibility_filter(self, mock_execute_async):
+        """
+        Test that transaction_visibility parameter is passed as transactionVisibility in GraphQL filters.
+        """
+        mock_execute_async.return_value = {
+            "allTransactions": {"results": [], "totalCount": 0},
+            "transactionRules": [],
+        }
+
+        await self.monarch_money.get_transactions(transaction_visibility="all_transactions")
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertIn("variable_values", kwargs)
+        self.assertEqual(
+            kwargs["variable_values"]["filters"]["transactionVisibility"],
+            "all_transactions",
+            "Expected transactionVisibility filter to be 'all_transactions'",
+        )
+
     @patch("builtins.input", return_value="")
     @patch("getpass.getpass", return_value="")
     async def test_interactive_login(self, _input_mock, _getpass_mock):

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -257,31 +257,6 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
             "Expected needsReview filter to be True",
         )
 
-    @patch.object(Client, "execute_async")
-    async def test_get_transactions_transaction_visibility_filter(
-        self, mock_execute_async
-    ):
-        """
-        Test that transaction_visibility parameter is passed as transactionVisibility in GraphQL filters.
-        """
-        mock_execute_async.return_value = {
-            "allTransactions": {"results": [], "totalCount": 0},
-            "transactionRules": [],
-        }
-
-        await self.monarch_money.get_transactions(
-            transaction_visibility="all_transactions"
-        )
-
-        mock_execute_async.assert_called_once()
-        kwargs = mock_execute_async.call_args.kwargs
-        self.assertIn("variable_values", kwargs)
-        self.assertEqual(
-            kwargs["variable_values"]["filters"]["transactionVisibility"],
-            "all_transactions",
-            "Expected transactionVisibility filter to be 'all_transactions'",
-        )
-
     @patch("builtins.input", return_value="")
     @patch("getpass.getpass", return_value="")
     async def test_interactive_login(self, _input_mock, _getpass_mock):

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -258,7 +258,9 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch.object(Client, "execute_async")
-    async def test_get_transactions_transaction_visibility_filter(self, mock_execute_async):
+    async def test_get_transactions_transaction_visibility_filter(
+        self, mock_execute_async
+    ):
         """
         Test that transaction_visibility parameter is passed as transactionVisibility in GraphQL filters.
         """
@@ -267,7 +269,9 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
             "transactionRules": [],
         }
 
-        await self.monarch_money.get_transactions(transaction_visibility="all_transactions")
+        await self.monarch_money.get_transactions(
+            transaction_visibility="all_transactions"
+        )
 
         mock_execute_async.assert_called_once()
         kwargs = mock_execute_async.call_args.kwargs


### PR DESCRIPTION
Adds `transaction_visibility` parameter to `get_transactions()`.  This matches the Monarch transaction filter setting Other -> Hidden to allow retrieving only non-hidden transactions (default), only hidden transactions, or all (hidden and non-hidden) transactions.

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [x] GraphQL endpoint/query update
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only

## Required For New Features Or Endpoint Changes

If this PR adds, updates, or fixes a Monarch feature or endpoint, include a sanitized Monarch response and DO NOT include real data. The PR will not be approved if a Monarch Response is not supplied.

- [ ] I included a sanitized Monarch response/example
- [ ] I removed or redacted any real personal or financial data

## Explain your Change Below and how can it be reproduced in Monarch? (It will be tested locally before final merge)

This change adds the transaction_visibility filter to match the transaction filter in Monarch available at Other -> Hidden.

* Navigate to transactions list
* Open filters
* Toggle setting of Hidden filter between "Hidden only" and "Hidden and not hidden"