### PR TITLE
Add optional typed Monarch Money client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests with unittest
         run: |
-          python -m unittest tests/test_monarchmoney.py
+          python -m unittest tests/test_monarchmoney.py tests/test_monarchmoney_typed.py

--- a/monarchmoney/__init__.py
+++ b/monarchmoney/__init__.py
@@ -1,8 +1,4 @@
-"""
-monarchmoney
-
-A Python API for interacting with MonarchMoney.
-"""
+"""Monarch Money clients and typed models."""
 
 from .monarchmoney import (
     CaptchaRequiredException,
@@ -12,6 +8,28 @@ from .monarchmoney import (
     RequireMFAException,
     RequestFailedException,
 )
+from .monarchmoney_typed import (
+    MonarchAccount,
+    MonarchCashflowSummary,
+    MonarchHolding,
+    MonarchHoldings,
+    MonarchMoneyTyped,
+    MonarchSubscription,
+)
 
 __version__ = "1.4.0"
 __author__ = "bradleyseanf"
+
+__all__ = [
+    "LoginFailedException",
+    "MonarchAccount",
+    "MonarchCashflowSummary",
+    "MonarchHolding",
+    "MonarchHoldings",
+    "MonarchMoney",
+    "MonarchMoneyEndpoints",
+    "RequireMFAException",
+    "RequestFailedException",
+    "MonarchSubscription",
+    "MonarchMoneyTyped",
+]

--- a/monarchmoney/monarchmoney_typed.py
+++ b/monarchmoney/monarchmoney_typed.py
@@ -54,7 +54,9 @@ class MonarchAccount:
         self.id = str(data.get("id", ""))
         self.logo_url = data.get("logoUrl") or institution.get("logo")
         self.name = data.get("displayName") or data.get("name") or ""
-        self.balance = _parse_float(data.get("currentBalance", data.get("displayBalance")))
+        self.balance = _parse_float(
+            data.get("currentBalance", data.get("displayBalance"))
+        )
         self.type = account_type.get("name", "")
         self.type_name = account_type.get("display", self.type)
         self.subtype = account_subtype.get("name", "")
@@ -63,7 +65,9 @@ class MonarchAccount:
             credential.get("dataProvider") or data.get("dataProvider") or "Manual entry"
         )
         self.last_update = _parse_datetime(
-            data.get("updatedAt") or data.get("displayLastUpdatedAt") or data.get("createdAt")
+            data.get("updatedAt")
+            or data.get("displayLastUpdatedAt")
+            or data.get("createdAt")
             or datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
         )
         self.date_created = _parse_datetime(
@@ -71,8 +75,12 @@ class MonarchAccount:
             or data.get("updatedAt")
             or datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
         )
-        self.institution_url = _normalize_url(institution.get("url") or data.get("institutionUrl"))
-        self.institution_name = institution.get("name") or data.get("institutionName") or "Manual entry"
+        self.institution_url = _normalize_url(
+            institution.get("url") or data.get("institutionUrl")
+        )
+        self.institution_name = (
+            institution.get("name") or data.get("institutionName") or "Manual entry"
+        )
         self.holdings = None
 
     @property
@@ -101,7 +109,11 @@ class MonarchCashflowSummary:
 
 class MonarchSubscription:
     def __init__(self, data: Dict[str, Any]) -> None:
-        subscription = data.get("subscription") if isinstance(data.get("subscription"), dict) else data
+        subscription = (
+            data.get("subscription")
+            if isinstance(data.get("subscription"), dict)
+            else data
+        )
         self.id = str(subscription.get("id", ""))
         self.payment_source = subscription.get("paymentSource", "")
         self.referral_code = subscription.get("referralCode", "")
@@ -124,7 +136,9 @@ class MonarchHolding:
             self.ticker = security.get("ticker", "")
             self.name = security.get("name") or first_holding.get("name", "")
             self.type = security.get("type") or first_holding.get("type")
-            self.type_name = security.get("typeDisplay") or first_holding.get("typeDisplay", "")
+            self.type_name = security.get("typeDisplay") or first_holding.get(
+                "typeDisplay", ""
+            )
             self.price = _parse_float(security.get("currentPrice"))
             self.price_date = security.get("currentPriceUpdatedAt")
         else:
@@ -147,7 +161,9 @@ class MonarchHoldings:
     ) -> None:
         self.holdings: List[MonarchHolding] = []
         self.total_value = 0.0
-        self._account = account_or_id if isinstance(account_or_id, MonarchAccount) else None
+        self._account = (
+            account_or_id if isinstance(account_or_id, MonarchAccount) else None
+        )
         self._account_id_str = (
             str(account_or_id.id)
             if isinstance(account_or_id, MonarchAccount)
@@ -161,7 +177,9 @@ class MonarchHoldings:
             self.total_value += holding.total_value
 
         for holding in self.holdings:
-            holding.percentage = (holding.total_value / self.total_value) if self.total_value else 0.0
+            holding.percentage = (
+                holding.total_value / self.total_value if self.total_value else 0.0
+            )
 
     def to_json(self) -> str:
         return json.dumps(
@@ -190,11 +208,15 @@ class TypedMonarchMoney(MonarchMoney):
     ) -> None:
         super().__init__(session_file, timeout, token)
 
-    async def get_accounts(self, *, with_holdings: bool = False) -> List[MonarchAccount]:
+    async def get_accounts(
+        self, *, with_holdings: bool = False
+    ) -> List[MonarchAccount]:
         data = await super().get_accounts()
         accounts = [MonarchAccount(account) for account in data.get("accounts", [])]
         if with_holdings and accounts:
-            holdings = await asyncio.gather(*(self.get_account_holdings(account) for account in accounts))
+            holdings = await asyncio.gather(
+                *(self.get_account_holdings(account) for account in accounts)
+            )
             for account, holding in zip(accounts, holdings):
                 account.holdings = holding
         return accounts
@@ -211,7 +233,9 @@ class TypedMonarchMoney(MonarchMoney):
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> MonarchCashflowSummary:
-        return MonarchCashflowSummary(await super().get_cashflow_summary(limit, start_date, end_date))
+        return MonarchCashflowSummary(
+            await super().get_cashflow_summary(limit, start_date, end_date)
+        )
 
     async def get_subscription_details(self) -> MonarchSubscription:
         return MonarchSubscription(await super().get_subscription_details())

--- a/monarchmoney/monarchmoney_typed.py
+++ b/monarchmoney/monarchmoney_typed.py
@@ -1,0 +1,233 @@
+"""Typed wrapper around Monarch Money."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
+from .monarchmoney import DEFAULT_RECORD_LIMIT, MonarchMoney, SESSION_FILE
+
+
+def _parse_float(value: Any, default: float = -1.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    value_str = str(value)
+    if value_str.endswith("Z"):
+        value_str = value_str[:-1] + "+00:00"
+    return datetime.fromisoformat(value_str)
+
+
+def _normalize_url(url: Optional[str]) -> str:
+    if not url:
+        return "https://monarch.com"
+    if url.startswith(("http://", "https://")):
+        return url
+    return f"http://{url}"
+
+
+VALUE_ACCOUNT_TYPES = {
+    "other_asset",
+    "other_assets",
+    "real-estate",
+    "real_estate",
+    "valuables",
+    "vehicle",
+}
+
+
+class MonarchAccount:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        institution = data.get("institution") or {}
+        credential = data.get("credential") or {}
+        account_type = data.get("type") or {}
+        account_subtype = data.get("subtype") or {}
+
+        self.id = str(data.get("id", ""))
+        self.logo_url = data.get("logoUrl") or institution.get("logo")
+        self.name = data.get("displayName") or data.get("name") or ""
+        self.balance = _parse_float(data.get("currentBalance", data.get("displayBalance")))
+        self.type = account_type.get("name", "")
+        self.type_name = account_type.get("display", self.type)
+        self.subtype = account_subtype.get("name", "")
+        self.subtype_name = account_subtype.get("display", self.subtype)
+        self.data_provider = (
+            credential.get("dataProvider") or data.get("dataProvider") or "Manual entry"
+        )
+        self.last_update = _parse_datetime(
+            data.get("updatedAt") or data.get("displayLastUpdatedAt") or data.get("createdAt")
+            or datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
+        )
+        self.date_created = _parse_datetime(
+            data.get("createdAt")
+            or data.get("updatedAt")
+            or datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
+        )
+        self.institution_url = _normalize_url(institution.get("url") or data.get("institutionUrl"))
+        self.institution_name = institution.get("name") or data.get("institutionName") or "Manual entry"
+        self.holdings = None
+
+    @property
+    def is_value_account(self) -> bool:
+        return self.type in VALUE_ACCOUNT_TYPES
+
+    @property
+    def is_balance_account(self) -> bool:
+        return not self.is_value_account
+
+
+class MonarchCashflowSummary:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        summary_data = data
+        summary = data.get("summary")
+        if isinstance(summary, list) and summary:
+            summary_data = summary[0].get("summary", summary[0])
+        elif isinstance(summary, dict):
+            summary_data = summary
+
+        self.income = _parse_float(summary_data.get("sumIncome", -1.0))
+        self.expenses = _parse_float(summary_data.get("sumExpense", -1.0))
+        self.savings = _parse_float(summary_data.get("savings", -1.0))
+        self.savings_rate = _parse_float(summary_data.get("savingsRate", -1.0))
+
+
+class MonarchSubscription:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        subscription = data.get("subscription") if isinstance(data.get("subscription"), dict) else data
+        self.id = str(subscription.get("id", ""))
+        self.payment_source = subscription.get("paymentSource", "")
+        self.referral_code = subscription.get("referralCode", "")
+        self.is_on_free_trial = bool(subscription.get("isOnFreeTrial"))
+        self.has_premium_entitlement = bool(subscription.get("hasPremiumEntitlement"))
+
+
+class MonarchHolding:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        node = data.get("node") or {}
+        holdings = node.get("holdings") or []
+        first_holding = holdings[0] if holdings else {}
+        security = node.get("security") or {}
+
+        self.total_value = _parse_float(node.get("totalValue"))
+        self.quantity = _parse_float(node.get("quantity"))
+        self.percentage = 0.0
+
+        if security:
+            self.ticker = security.get("ticker", "")
+            self.name = security.get("name") or first_holding.get("name", "")
+            self.type = security.get("type") or first_holding.get("type")
+            self.type_name = security.get("typeDisplay") or first_holding.get("typeDisplay", "")
+            self.price = _parse_float(security.get("currentPrice"))
+            self.price_date = security.get("currentPriceUpdatedAt")
+        else:
+            self.ticker = first_holding.get("ticker", "")
+            self.name = first_holding.get("name", "")
+            self.type = first_holding.get("type")
+            self.type_name = first_holding.get("typeDisplay", "")
+            self.price = _parse_float(first_holding.get("closingPrice"))
+            self.price_date = first_holding.get("closingPriceUpdatedAt")
+            if self.ticker == "CUR:USD" and not self.name:
+                self.name = "cash"
+                self.price = 1.0
+
+
+class MonarchHoldings:
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        account_or_id: Optional[Union[MonarchAccount, int, str]] = None,
+    ) -> None:
+        self.holdings: List[MonarchHolding] = []
+        self.total_value = 0.0
+        self._account = account_or_id if isinstance(account_or_id, MonarchAccount) else None
+        self._account_id_str = (
+            str(account_or_id.id)
+            if isinstance(account_or_id, MonarchAccount)
+            else str(account_or_id) if account_or_id is not None else "UNKNOWN"
+        )
+
+        edges = data.get("portfolio", {}).get("aggregateHoldings", {}).get("edges", [])
+        for item in edges:
+            holding = MonarchHolding(item)
+            self.holdings.append(holding)
+            self.total_value += holding.total_value
+
+        for holding in self.holdings:
+            holding.percentage = (holding.total_value / self.total_value) if self.total_value else 0.0
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                holding.ticker: {
+                    "quantity": holding.quantity,
+                    "totalValue": holding.total_value,
+                    "type": holding.type_name,
+                    "percentage": round(holding.percentage * 100.0, 1),
+                    "name": holding.name,
+                    "sharePrice": holding.price,
+                    "sharePriceUpdate": holding.price_date,
+                }
+                for holding in self.holdings
+            },
+            separators=(",", ":"),
+        )
+
+
+class TypedMonarchMoney(MonarchMoney):
+    def __init__(
+        self,
+        session_file: str = SESSION_FILE,
+        timeout: int = 10,
+        token: Optional[str] = None,
+    ) -> None:
+        super().__init__(session_file, timeout, token)
+
+    async def get_accounts(self, *, with_holdings: bool = False) -> List[MonarchAccount]:
+        data = await super().get_accounts()
+        accounts = [MonarchAccount(account) for account in data.get("accounts", [])]
+        if with_holdings and accounts:
+            holdings = await asyncio.gather(*(self.get_account_holdings(account) for account in accounts))
+            for account, holding in zip(accounts, holdings):
+                account.holdings = holding
+        return accounts
+
+    async def get_accounts_as_dict_with_id_key(
+        self, *, with_holdings: bool = False
+    ) -> Dict[str, MonarchAccount]:
+        accounts = await self.get_accounts(with_holdings=with_holdings)
+        return {account.id: account for account in accounts}
+
+    async def get_cashflow_summary(
+        self,
+        limit: int = DEFAULT_RECORD_LIMIT,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> MonarchCashflowSummary:
+        return MonarchCashflowSummary(await super().get_cashflow_summary(limit, start_date, end_date))
+
+    async def get_subscription_details(self) -> MonarchSubscription:
+        return MonarchSubscription(await super().get_subscription_details())
+
+    async def get_account_holdings_for_id(
+        self, account_id: Union[str, int]
+    ) -> Optional[MonarchHoldings]:
+        data = await super().get_account_holdings(int(account_id))
+        edges = data.get("portfolio", {}).get("aggregateHoldings", {}).get("edges", [])
+        if not edges:
+            return None
+        return MonarchHoldings(data, account_id)
+
+    async def get_account_holdings(
+        self, account: Union[MonarchAccount, str, int]
+    ) -> Optional[MonarchHoldings]:
+        if isinstance(account, MonarchAccount):
+            return await self.get_account_holdings_for_id(account.id)
+        return await self.get_account_holdings_for_id(account)

--- a/monarchmoney/monarchmoney_typed.py
+++ b/monarchmoney/monarchmoney_typed.py
@@ -255,3 +255,4 @@ class TypedMonarchMoney(MonarchMoney):
         if isinstance(account, MonarchAccount):
             return await self.get_account_holdings_for_id(account.id)
         return await self.get_account_holdings_for_id(account)
+MonarchMoneyTyped = TypedMonarchMoney

--- a/monarchmoney/monarchmoney_typed.py
+++ b/monarchmoney/monarchmoney_typed.py
@@ -167,7 +167,9 @@ class MonarchHoldings:
         self._account_id_str = (
             str(account_or_id.id)
             if isinstance(account_or_id, MonarchAccount)
-            else str(account_or_id) if account_or_id is not None else "UNKNOWN"
+            else str(account_or_id)
+            if account_or_id is not None
+            else "UNKNOWN"
         )
 
         edges = data.get("portfolio", {}).get("aggregateHoldings", {}).get("edges", [])
@@ -255,4 +257,6 @@ class TypedMonarchMoney(MonarchMoney):
         if isinstance(account, MonarchAccount):
             return await self.get_account_holdings_for_id(account.id)
         return await self.get_account_holdings_for_id(account)
+
+
 MonarchMoneyTyped = TypedMonarchMoney

--- a/monarchmoney/monarchmoney_typed.py
+++ b/monarchmoney/monarchmoney_typed.py
@@ -167,9 +167,7 @@ class MonarchHoldings:
         self._account_id_str = (
             str(account_or_id.id)
             if isinstance(account_or_id, MonarchAccount)
-            else str(account_or_id)
-            if account_or_id is not None
-            else "UNKNOWN"
+            else str(account_or_id) if account_or_id is not None else "UNKNOWN"
         )
 
         edges = data.get("portfolio", {}).get("aggregateHoldings", {}).get("edges", [])

--- a/tests/test_monarchmoney_typed.py
+++ b/tests/test_monarchmoney_typed.py
@@ -45,7 +45,16 @@ class TestMonarchMoneyTyped(unittest.IsolatedAsyncioTestCase):
     @patch.object(Client, "execute_async")
     async def test_cashflow_and_subscription_are_typed(self, mock_execute_async):
         mock_execute_async.return_value = {
-            "summary": [{"summary": {"sumIncome": 8, "sumExpense": -3, "savings": 5, "savingsRate": 0.625}}],
+            "summary": [
+                {
+                    "summary": {
+                        "sumIncome": 8,
+                        "sumExpense": -3,
+                        "savings": 5,
+                        "savingsRate": 0.625,
+                    }
+                }
+            ],
             "subscription": {
                 "id": "185960257876876964",
                 "paymentSource": "STRIPE",
@@ -65,12 +74,15 @@ class TestMonarchMoneyTyped(unittest.IsolatedAsyncioTestCase):
 
     @patch.object(Client, "execute_async")
     async def test_holdings_are_typed(self, mock_execute_async):
-        mock_execute_async.return_value = self.load_test_data("get_account_holdings.json")
-        account = MonarchAccount(self.load_test_data("get_accounts.json")["accounts"][4])
+        mock_execute_async.return_value = self.load_test_data(
+            "get_account_holdings.json"
+        )
+        account = MonarchAccount(
+            self.load_test_data("get_accounts.json")["accounts"][4]
+        )
 
         holdings = await self.monarch_money.get_account_holdings(account)
 
         self.assertIsInstance(holdings, MonarchHoldings)
         self.assertEqual(len(holdings.holdings), 3)
         self.assertEqual(holdings.holdings[0].ticker, "CMF")
-

--- a/tests/test_monarchmoney_typed.py
+++ b/tests/test_monarchmoney_typed.py
@@ -1,0 +1,76 @@
+import json
+import os
+import pickle
+import unittest
+from unittest.mock import patch
+
+from gql import Client
+
+from monarchmoney.monarchmoney_typed import (
+    MonarchAccount,
+    MonarchCashflowSummary,
+    MonarchHoldings,
+    MonarchSubscription,
+    TypedMonarchMoney,
+)
+
+
+class TestMonarchMoneyTyped(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.session_file = "temp_typed_session.pickle"
+        with open(self.session_file, "wb") as fh:
+            pickle.dump({"cookies": {}, "token": "test_token"}, fh)
+        self.monarch_money = TypedMonarchMoney()
+        self.monarch_money.load_session(self.session_file)
+
+    def tearDown(self):
+        self.monarch_money.delete_session(self.session_file)
+
+    @classmethod
+    def load_test_data(cls, filename: str) -> dict:
+        path = os.path.join(os.path.dirname(__file__), filename)
+        with open(path, "r") as fh:
+            return json.load(fh)
+
+    @patch.object(Client, "execute_async")
+    async def test_accounts_are_typed(self, mock_execute_async):
+        mock_execute_async.return_value = self.load_test_data("get_accounts.json")
+
+        accounts = await self.monarch_money.get_accounts()
+
+        self.assertIsInstance(accounts[0], MonarchAccount)
+        self.assertEqual(accounts[0].name, "Brokerage")
+        self.assertEqual(accounts[4].type, "real_estate")
+
+    @patch.object(Client, "execute_async")
+    async def test_cashflow_and_subscription_are_typed(self, mock_execute_async):
+        mock_execute_async.return_value = {
+            "summary": [{"summary": {"sumIncome": 8, "sumExpense": -3, "savings": 5, "savingsRate": 0.625}}],
+            "subscription": {
+                "id": "185960257876876964",
+                "paymentSource": "STRIPE",
+                "referralCode": "go3dpvrdmw",
+                "isOnFreeTrial": True,
+                "hasPremiumEntitlement": True,
+            },
+        }
+
+        summary = await self.monarch_money.get_cashflow_summary()
+        subscription = await self.monarch_money.get_subscription_details()
+
+        self.assertIsInstance(summary, MonarchCashflowSummary)
+        self.assertEqual(summary.income, 8.0)
+        self.assertIsInstance(subscription, MonarchSubscription)
+        self.assertEqual(subscription.id, "185960257876876964")
+
+    @patch.object(Client, "execute_async")
+    async def test_holdings_are_typed(self, mock_execute_async):
+        mock_execute_async.return_value = self.load_test_data("get_account_holdings.json")
+        account = MonarchAccount(self.load_test_data("get_accounts.json")["accounts"][4])
+
+        holdings = await self.monarch_money.get_account_holdings(account)
+
+        self.assertIsInstance(holdings, MonarchHoldings)
+        self.assertEqual(len(holdings.holdings), 3)
+        self.assertEqual(holdings.holdings[0].ticker, "CMF")
+

--- a/tests/test_monarchmoney_typed.py
+++ b/tests/test_monarchmoney_typed.py
@@ -6,11 +6,15 @@ from unittest.mock import patch
 
 from gql import Client
 
-from monarchmoney.monarchmoney_typed import (
+from monarchmoney import (
     MonarchAccount,
     MonarchCashflowSummary,
+    MonarchHolding,
     MonarchHoldings,
     MonarchSubscription,
+    MonarchMoneyTyped,
+)
+from monarchmoney.monarchmoney_typed import (
     TypedMonarchMoney,
 )
 
@@ -22,6 +26,9 @@ class TestMonarchMoneyTyped(unittest.IsolatedAsyncioTestCase):
             pickle.dump({"cookies": {}, "token": "test_token"}, fh)
         self.monarch_money = TypedMonarchMoney()
         self.monarch_money.load_session(self.session_file)
+
+    def test_top_level_monarch_money_aliases_typed_client(self):
+        self.assertIs(MonarchMoneyTyped, TypedMonarchMoney)
 
     def tearDown(self):
         self.monarch_money.delete_session(self.session_file)
@@ -86,3 +93,4 @@ class TestMonarchMoneyTyped(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(holdings, MonarchHoldings)
         self.assertEqual(len(holdings.holdings), 3)
         self.assertEqual(holdings.holdings[0].ticker, "CMF")
+        self.assertIsInstance(holdings.holdings[0], MonarchHolding)


### PR DESCRIPTION
## Addition of an Optional Typed Monarch Money Client

Used here -> https://github.com/jeeftor/monarchmoney-typed created by @jeeftor

This client Powers the home assistant integration -> https://www.home-assistant.io/integrations/monarch_money/ and here https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money

To vertically integrate a typed client in monarchmoneycommunity for optional use. 

