### PR TITLE
fix: remove token auth, clarify TOTP and cookie auth paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,19 @@ await mm.interactive_login()
 
 ## Option 3: Browser cookies (use when CAPTCHA blocks login)
 
-If Monarch blocks the programmatic login with a CAPTCHA, authenticate via your browser instead:
+If Monarch blocks the programmatic login with a CAPTCHA, authenticate via your browser instead.
+
+> **Important:** Use the **Network tab** to get your cookies, not the Application/Cookies tab.
+> The Application tab shows the frontend session cookie, which is different from the API session
+> cookie that this library needs. The Network tab shows the exact cookies sent to the API.
+
+**Steps:**
 
 1. Open [app.monarch.com](https://app.monarch.com) and log in normally
-2. Open DevTools → **Application** → **Cookies** → `app.monarch.com`
-3. Copy the values of `session_id` and `csrftoken`
+2. Open DevTools (F12) → **Network** tab
+3. Reload the page, then filter requests by `graphql`
+4. Click any request to `api.monarch.com/graphql` → **Headers** → **Request Headers**
+5. Find the `Cookie:` header and copy its full value
 
 ```python
 from monarchmoney import MonarchMoney
@@ -86,6 +94,9 @@ from monarchmoney import MonarchMoney
 mm = MonarchMoney()
 await mm.login_with_cookies("session_id=xxx; csrftoken=yyy")
 ```
+
+You can pass the entire cookie string copied from the Network tab — the library will extract
+`session_id` and `csrftoken` and ignore the rest.
 
 # Use a Saved Session
 

--- a/README.md
+++ b/README.md
@@ -33,56 +33,58 @@ Import the library as `monarchmoney` after installation.
 This package pins `gql` to `4.0`.
 # Instantiate & Login
 
-There are two ways to use this library: interactive and non-interactive.
+Monarch Money requires multi-factor authentication and increasingly blocks programmatic logins with CAPTCHA. There are three supported auth approaches — pick the one that works for your setup.
 
-## Interactive
+## Option 1: TOTP secret key (fully automated, recommended for scripts)
 
-If you're using this library in something like iPython or Jupyter, you can run an interactive-login which supports multi-factor authentication:
-
-```python
-from monarchmoney import MonarchMoney
-
-mm = MonarchMoney()
-await mm.interactive_login()
-```
-This will prompt you for the email, password and, if needed, the multi-factor token.
-
-## Non-interactive
-
-For a non-interactive session, you'll need to create an instance and login:
+If you have the base-32 secret from when you set up your authenticator app, the library can generate the 6-digit code automatically. In Monarch, go to **Settings → Security → Two-factor authentication** and copy the **"Two-factor text code"** (the raw base-32 string, not the QR code).
 
 ```python
 from monarchmoney import MonarchMoney
 
 mm = MonarchMoney()
-await mm.login(email, password)
+await mm.login(
+    email="you@example.com",
+    password="yourpassword",
+    mfa_secret_key="BASE32TOTPSECRETHERE",
+)
 ```
 
-This may throw a `RequireMFAException`.  If it does, you'll need to get a multi-factor token and call the following method:
+## Option 2: Interactive MFA code prompt
+
+If you don't have the base-32 secret but can read a 6-digit code from your authenticator app:
 
 ```python
 from monarchmoney import MonarchMoney, RequireMFAException
 
 mm = MonarchMoney()
 try:
-        await mm.login(email, password)
+    await mm.login(email="you@example.com", password="yourpassword")
 except RequireMFAException:
-        await mm.multi_factor_authenticate(email, password, multi_factor_code)
+    code = input("Enter your 6-digit MFA code: ")
+    await mm.multi_factor_authenticate("you@example.com", "yourpassword", code)
 ```
 
-Alternatively, you can provide the MFA Secret Key. The MFA Secret Key is found when setting up the MFA in Monarch Money by going to Settings -> Security -> Enable MFA -> and copy the `Two-factor text code`. Then provide it in the login() method:
+For iPython / Jupyter, `interactive_login()` handles this automatically:
+
 ```python
-from monarchmoney import MonarchMoney, RequireMFAException
+mm = MonarchMoney()
+await mm.interactive_login()
+```
+
+## Option 3: Browser cookies (use when CAPTCHA blocks login)
+
+If Monarch blocks the programmatic login with a CAPTCHA, authenticate via your browser instead:
+
+1. Open [app.monarch.com](https://app.monarch.com) and log in normally
+2. Open DevTools → **Application** → **Cookies** → `app.monarch.com`
+3. Copy the values of `session_id` and `csrftoken`
+
+```python
+from monarchmoney import MonarchMoney
 
 mm = MonarchMoney()
-await mm.login(
-        email=email,
-        password=password,
-        save_session=False,
-        use_saved_session=False,
-        mfa_secret_key=mfa_secret_key,
-    )
-
+await mm.login_with_cookies("session_id=xxx; csrftoken=yyy")
 ```
 
 # Use a Saved Session

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -8,6 +8,7 @@ import os
 import sys
 import pickle
 import time
+from urllib.parse import unquote
 from dataclasses import dataclass
 from io import StringIO
 from datetime import datetime, date, timedelta
@@ -155,7 +156,7 @@ class MonarchMoney(object):
             if "=" not in pair:
                 continue
             key, _, value = pair.partition("=")
-            cookies[key.strip()] = value.strip()
+            cookies[key.strip()] = unquote(value.strip())
         return cookies
 
     async def interactive_login(

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -3607,7 +3607,7 @@ class MonarchMoney(object):
                 return
 
         if data.get("token"):
-            self.set_token(data["token"])
+            self._token = data["token"]
             self._headers["Authorization"] = f"Token {self._token}"
         else:
             raise LoginFailedException(
@@ -3704,7 +3704,7 @@ class MonarchMoney(object):
                         "Retry with trusted_device=True or complete MFA as trusted device."
                     )
 
-                self.set_token(tok)
+                self._token = tok
                 self._headers["Authorization"] = f"Token {self._token}"
 
     async def _multi_factor_authenticate(
@@ -3789,7 +3789,7 @@ class MonarchMoney(object):
                         "Make sure trusted_device=True when performing MFA."
                     )
 
-                self.set_token(tok)
+                self._token = tok
                 self._headers["Authorization"] = f"Token {self._token}"
 
     def _get_graphql_client(self) -> Client:

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -87,7 +87,6 @@ class MonarchMoney(object):
         self,
         session_file: str = SESSION_FILE,
         timeout: int = 10,
-        token: Optional[str] = None,
     ) -> None:
         self._headers = {
             "Accept": "application/json",
@@ -95,11 +94,9 @@ class MonarchMoney(object):
             "Content-Type": "application/json",
             "User-Agent": "MonarchMoneyAPI (https://github.com/bradleyseanf/monarchmoneycommunity)",
         }
-        if token:
-            self._headers["Authorization"] = f"Token {token}"
 
         self._session_file = session_file
-        self._token = token
+        self._token: Optional[str] = None
         self._cookies: Optional[Dict[str, str]] = None
         self._auth_mode: str = "token"
         self._timeout = timeout
@@ -122,13 +119,6 @@ class MonarchMoney(object):
     def set_timeout(self, timeout_secs: int) -> None:
         """Sets the default timeout on GraphQL API calls, in seconds."""
         self._timeout = timeout_secs
-
-    @property
-    def token(self) -> Optional[str]:
-        return self._token
-
-    def set_token(self, token: str) -> None:
-        self._token = token
 
     def set_cookies(self, cookies: Dict[str, str]) -> None:
         missing = [k for k in REQUIRED_COOKIES if k not in cookies]
@@ -3660,15 +3650,24 @@ class MonarchMoney(object):
                         body = await resp.json()
                         if body.get("error_code") == "CAPTCHA_REQUIRED":
                             raise CaptchaRequiredException(
-                                "Programmatic login is blocked by CAPTCHA. "
-                                "Use login_with_cookies() to authenticate with "
-                                "browser cookies instead."
+                                "Monarch blocked this login attempt with a CAPTCHA.\n\n"
+                                "Two ways to get around this:\n"
+                                "  1. If you have your authenticator app's base-32 secret key,\n"
+                                "     pass it as mfa_secret_key= to login() for fully automated auth.\n"
+                                "  2. Otherwise, grab your browser cookies from app.monarch.com\n"
+                                "     (DevTools → Application → Cookies → copy session_id and csrftoken)\n"
+                                "     and call login_with_cookies('session_id=xxx; csrftoken=yyy') instead."
                             )
                     except CaptchaRequiredException:
                         raise
                     except Exception:
                         pass
-                    raise RequireMFAException("Multi-Factor Auth Required")
+                    raise RequireMFAException(
+                        "Monarch requires multi-factor authentication.\n"
+                        "Call multi_factor_authenticate(email, password, code) with the\n"
+                        "6-digit code from your authenticator app.\n"
+                        "Or pass mfa_secret_key= to login() to generate the code automatically."
+                    )
                 if resp.status != 200:
                     try:
                         response = await resp.json()
@@ -3737,15 +3736,21 @@ class MonarchMoney(object):
                         body = await resp.json()
                         if body.get("error_code") == "CAPTCHA_REQUIRED":
                             raise CaptchaRequiredException(
-                                "Programmatic login is blocked by CAPTCHA. "
-                                "Use login_with_cookies() to authenticate with "
-                                "browser cookies instead."
+                                "Monarch blocked this MFA attempt with a CAPTCHA.\n\n"
+                                "Two ways to get around this:\n"
+                                "  1. If you have your authenticator app's base-32 secret key,\n"
+                                "     pass it as mfa_secret_key= to login() for fully automated auth.\n"
+                                "  2. Otherwise, grab your browser cookies from app.monarch.com\n"
+                                "     (DevTools → Application → Cookies → copy session_id and csrftoken)\n"
+                                "     and call login_with_cookies('session_id=xxx; csrftoken=yyy') instead."
                             )
                     except CaptchaRequiredException:
                         raise
                     except Exception:
                         pass
-                    raise RequireMFAException("Multi-Factor Auth Required")
+                    raise RequireMFAException(
+                        "MFA attempt failed — check that your 6-digit code is correct and has not expired."
+                    )
                 if resp.status != 200:
                     try:
                         response = await resp.json()


### PR DESCRIPTION
## Summary

- Removes the `token=` constructor parameter and `set_token()` public method. Monarch Money no longer supports direct API token injection, so accepting one was misleading.
- The two supported auth paths going forward are: `login()` with `mfa_secret_key=` for fully automated TOTP-based auth, or `login_with_cookies()` when CAPTCHA blocks programmatic login.
- Improves `CaptchaRequiredException` and `RequireMFAException` messages to clearly describe both working alternatives (TOTP secret key or browser cookies) with step-by-step guidance.
- Rewrites the README login section to lead with three clearly numbered options: TOTP secret (recommended for scripts), interactive MFA code prompt, and browser cookies.

## Breaking change

`MonarchMoney(token="...")` and `mm.set_token(...)` are removed. Users relying on these should switch to `login(mfa_secret_key=...)` or `login_with_cookies(...)`.

## Test plan

- [x] `MonarchMoney(token="...")` raises `TypeError` (constructor no longer accepts that param)
- [x] `login(email, password, mfa_secret_key="BASE32SECRET")` authenticates successfully
- [x] `login(email, password)` followed by `multi_factor_authenticate(...)` works
- [x] `login_with_cookies("session_id=xxx; csrftoken=yyy")` still works
- [ ] `login(email, password)` when CAPTCHA-blocked raises `CaptchaRequiredException` with helpful message listing both alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)