### PR TITLE
Add liability fields to get_accounts AccountFields fragment

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -318,6 +318,13 @@ class MonarchMoney(object):
               url
               __typename
             }
+            limit
+            dataProviderCreditLimit
+            apr
+            interestRate
+            minimumPayment
+            plannedPayment
+            excludeFromDebtPaydown
             __typename
           }
         """


### PR DESCRIPTION
Add limit, dataProviderCreditLimit, apr, interestRate, minimumPayment, plannedPayment, and excludeFromDebtPaydown to the AccountFields fragment.

## Type Of Change

- [ ] Bug fix
- [ ] New feature (new endpoint / method)
- [X] GraphQL endpoint/query update
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only


## Required For New Features Or Endpoint Changes

This requests additional fields that already exist on the `Account` type within the existing `GetAccounts` query used
by `get_accounts()`.

**Monarch URL:** `https://api.monarch.com/graphql`

**Request payload**: `get_accounts()` sends, POSTed as
`{"operationName":"GetAccounts","variables":{},"query":"<document below>"}`. The
seven fields this PR adds are at the end of the `AccountFields` fragment; the rest
is the pre-existing selection:

```graphql
query GetAccounts {
  accounts {
    ...AccountFields
    __typename
  }
  householdPreferences {
    id
    accountGroupOrder
    __typename
  }
}

fragment AccountFields on Account {
  id
  displayName
  syncDisabled
  deactivatedAt
  isHidden
  isAsset
  mask
  createdAt
  updatedAt
  displayLastUpdatedAt
  currentBalance
  displayBalance
  includeInNetWorth
  hideFromList
  hideTransactionsFromReports
  includeBalanceInNetWorth
  includeInGoalBalance
  dataProvider
  dataProviderAccountId
  isManual
  transactionsCount
  holdingsCount
  manualInvestmentsTrackingMethod
  order
  logoUrl
  type { name display __typename }
  subtype { name display __typename }
  credential {
    id
    updateRequired
    disconnectedFromDataProviderAt
    dataProvider
    institution { id plaidInstitutionId name status __typename }
    __typename
  }
  institution { id name primaryColor url __typename }
  limit
  dataProviderCreditLimit
  apr
  interestRate
  minimumPayment
  plannedPayment
  excludeFromDebtPaydown
  __typename
}
```

**Response** one account sample, truncated to the new liability fields plus a few
identifiers; ids, names, masks and balances (redacted for my privacy):

```json
{
  "data": {
    "accounts": [
      {
        "id": "<redacted>",
        "displayName": "<redacted>",
        "mask": "<redacted>",
        "currentBalance": -1234.56,
        "type": { "name": "credit", "display": "Credit Card", "__typename": "AccountType" },
        "subtype": { "name": "credit_card", "display": "Credit Card", "__typename": "AccountSubtype" },
        "limit": 10000.0,
        "dataProviderCreditLimit": 10000.0,
        "apr": 24.99,
        "interestRate": null,
        "minimumPayment": 40.0,
        "plannedPayment": null,
        "excludeFromDebtPaydown": false,
        "__typename": "Account"
      }
    ],
    "householdPreferences": { "id": "<redacted>", "accountGroupOrder": [], "__typename": "HouseholdPreferences" }
  }
}
```

_(Remaining `AccountFields` and the other accounts omitted for brevity. For a loan
the rate is in `interestRate` with `apr: null`; for a credit card it is in `apr`
with `interestRate: null`.)_

**Required headers (sanitized):**

```
Content-Type: application/json
Authorization: Token <REDACTED>
Client-Platform: web
Cookie: <REDACTED>
```

These same fields are also visible in the current Monarch web app on any account's
detail page (`https://app.monarch.com/accounts/<id>`); its account-detail GraphQL
request (operation `Common_AccountDetails_getAccount`) requests the same fields,
which is how they were identified.

- [X] I included the Monarch URL where this request occurs
- [X] I included a sanitized request payload example
- [X] I redacted any personal or financial data


## README Update Requirement (required for new features)

- [ ] I updated the README to document the new method


## Explain the Change

`get_accounts()` never requested the liability detail that already exists on the
`Account` type so the fields are valid on `Account` but were absent from the
`AccountFields` fragment. This adds seven of them:

- `limit`: credit limit
- `dataProviderCreditLimit`: provider-reported credit limit
- `apr`: the rate for credit cards (loans leave this null)
- `interestRate`: the rate for loans (credit cards leave this null)
- `minimumPayment`
- `plannedPayment`
- `excludeFromDebtPaydown`: Monarch's per-account "exclude from debt paydown" flag (this is used in the goals' pay down view)

Reproduce by sending the `GetAccounts` payload above to
`https://api.monarch.com/graphql`, or by opening an account detail page in the web
app and inspecting the `Common_AccountDetails_getAccount` request in DevTools.


## PICTURES OF BROWSER REQUEST PAYLOAD ARE APPRECIATED BUT NOT NECESSARY - IF DOING SO, MAKE SURE TO REDACT PERSONAL INFORMATION!!!
