### PR TITLE
v1.5.0

### DIFF
--- a/monarchmoney/__init__.py
+++ b/monarchmoney/__init__.py
@@ -17,7 +17,7 @@ from .monarchmoney_typed import (
     MonarchSubscription,
 )
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __author__ = "bradleyseanf"
 
 __all__ = [


### PR DESCRIPTION
## VERSION 1.5.0

- NEW OPTIONAL TYPED CLIENT USES ```from monarchmoney import MonarchMoneyTyped``` BUILT FOR [HOME ASSISTANT INTEGRATION](https://www.home-assistant.io/integrations/monarch_money/)