### PR TITLE
Raise login failed for bad mfa codes

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -3886,7 +3886,7 @@ class MonarchMoney(object):
                     try:
                         response = await resp.json()
                         if "detail" in response:
-                            raise RequireMFAException(response["detail"])
+                            raise LoginFailedException(response["detail"])
                         if "error_code" in response:
                             raise LoginFailedException(response["error_code"])
                         raise LoginFailedException(f"Unrecognized error: {response}")

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import json
 from gql import Client
@@ -265,6 +265,35 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
         """
         with self.assertRaises(LoginFailedException):
             await self.monarch_money.interactive_login(use_saved_session=False)
+
+    @patch("monarchmoney.monarchmoney.ClientSession")
+    async def test_multi_factor_authenticate_bad_code_raises_login_failed(
+        self, mock_client_session
+    ):
+        """
+        Bad MFA codes should raise LoginFailedException, not RequireMFAException.
+        """
+        response = AsyncMock()
+        response.status = 400
+        response.reason = "Bad Request"
+        response.json = AsyncMock(return_value={"detail": "Invalid MFA code"})
+
+        post_context = MagicMock()
+        post_context.__aenter__.return_value = response
+
+        session = MagicMock()
+        session.post.return_value = post_context
+
+        client_context = MagicMock()
+        client_context.__aenter__.return_value = session
+        mock_client_session.return_value = client_context
+
+        with self.assertRaises(LoginFailedException) as ctx:
+            await self.monarch_money.multi_factor_authenticate(
+                "bradley@example.com", "password", "123456"
+            )
+
+        self.assertEqual(str(ctx.exception), "Invalid MFA code")
 
     @classmethod
     def loadTestData(cls, filename) -> dict:


### PR DESCRIPTION
## Type Of Change

- [x] Bug fix
- [ ] New feature (new endpoint / method)
- [ ] GraphQL endpoint/query update
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only


## Required For New Features Or Endpoint Changes

If this PR adds or changes a Monarch endpoint or method, you must provide enough detail for the endpoint to be reproduced locally using browser DevTools.

Provide:

• The Monarch URL where the request occurs  
• The request payload from the browser (sanitized)  
• Any required headers if relevant (sanitized)  

Do NOT include real financial or personal data.

The PR will not be approved if this information is missing.

- [ ] I included the Monarch URL where this request occurs
- [ ] I included a sanitized request payload example
- [ ] I redacted any personal or financial data


## README Update Requirement (required for new features)

If this PR adds a new endpoint or method (example: `get_accounts()`), you must include a commit updating the README with:

• method name  
• parameters  
• example usage  

- [ ] I updated the README to document the new method


## Explain the Change

Describe what was changed and how it can be reproduced in Monarch.
Keep concise.
```
Raise a login failed exception on failed MFA codes. At the moment will throw a keyError or authError.
This resolves this issue.








```


## PICTURES OF BROWSER REQUEST PAYLOAD ARE APPRECIATED BUT NOT NECESSARY - IF DOING SO, MAKE SURE TO REDACT PERSONAL INFORMATION!!!
