### PR TITLE
Add transaction rules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ As of writing this README, the following methods are supported:
       <td>gets transaction data, defaults to returning the last 100 transactions; can also be searched by date range</td>
     </tr>
     <tr>
+      <td><code>get_transaction_rules</code></td>
+      <td>gets all configured transaction rules, including their order, criteria, and actions</td>
+    </tr>
+    <tr>
+      <td><code>preview_transaction_rule</code></td>
+      <td>previews the transactions that would be affected by a transaction rule</td>
+    </tr>
+    <tr>
       <td><code>find_duplicate_transactions</code></td>
       <td>finds duplicate transaction groups using Plaid-reported fields</td>
     </tr>
@@ -247,6 +255,26 @@ As of writing this README, the following methods are supported:
       <td>modifies one or more attributes for an existing transaction</td>
     </tr>
     <tr>
+      <td><code>create_transaction_rule</code></td>
+      <td>creates a transaction rule from a Monarch rule input dictionary</td>
+    </tr>
+    <tr>
+      <td><code>update_transaction_rule</code></td>
+      <td>updates an existing transaction rule from a Monarch rule input dictionary</td>
+    </tr>
+    <tr>
+      <td><code>update_transaction_rule_order</code></td>
+      <td>updates a transaction rule's order and returns the reordered rule list</td>
+    </tr>
+    <tr>
+      <td><code>delete_transaction_rule</code></td>
+      <td>deletes a transaction rule by the provided rule id</td>
+    </tr>
+    <tr>
+      <td><code>delete_all_transaction_rules</code></td>
+      <td>deletes all transaction rules configured in the account</td>
+    </tr>
+    <tr>
       <td><code>update_reoccuring</code></td>
       <td>updates recurring merchant settings (frequency, amount, date, active status)</td>
     </tr>
@@ -308,6 +336,84 @@ As of writing this README, the following methods are supported:
     </tr>
   </tbody>
 </table>
+
+## Transaction Rules
+
+Transaction rules are returned in Monarch's configured order and use raw Monarch GraphQL dictionaries. This makes it possible to inspect, preview, create, update, reorder, and delete rules without re-implementing rule state outside Monarch. Monarch does not expose GraphQL schema introspection to non-admin users, so the fields below are based on Monarch's web app operations and live API testing.
+
+```python
+from monarchmoney import MonarchMoney
+
+mm = MonarchMoney()
+mm.load_session()
+
+categories = await mm.get_transaction_categories()
+category_id = categories["categories"][0]["id"]
+
+rule = {
+    "merchantCriteria": [
+        {
+            "operator": "contains",
+            "value": "example merchant",
+        }
+    ],
+    "setCategoryAction": category_id,
+    "applyToExistingTransactions": False,
+}
+
+preview = await mm.preview_transaction_rule(rule)
+created = await mm.create_transaction_rule(rule)
+rule_id = created["createTransactionRuleV2"]["transactionRule"]["id"]
+
+await mm.update_transaction_rule(
+    rule_id,
+    {
+        "merchantCriteria": [
+            {
+                "operator": "contains",
+                "value": "updated example merchant",
+            }
+        ],
+        "setCategoryAction": category_id,
+        "setHideFromReportsAction": True,
+        "applyToExistingTransactions": False,
+    },
+)
+
+await mm.update_transaction_rule_order(rule_id, 0)
+await mm.delete_transaction_rule(rule_id)
+```
+
+Common rule criteria fields:
+
+- `merchantCriteria`: match Monarch's merchant field with criteria like `{"operator": "contains", "value": "merchant"}`. Monarch lowercases merchant criterion values when saving rules.
+- `merchantNameCriteria`: match the displayed merchant name.
+- `originalStatementCriteria`: match the original statement text.
+- `amountCriteria`: match amounts, for example `{"operator": "equals", "isExpense": True, "value": 12.34, "valueRange": None}`.
+- `categoryIds`: restrict matches to one or more category IDs.
+- `accountIds`: restrict matches to one or more account IDs.
+- `criteriaOwnerUserIds` and `criteriaOwnerIsJoint`: restrict matches by transaction owner.
+- `criteriaBusinessEntityIds` and `criteriaBusinessEntityIsUnassigned`: restrict matches by business entity.
+
+Common rule action fields:
+
+- `setMerchantAction`: rename the merchant.
+- `setCategoryAction`: set a category by category ID.
+- `addTagsAction`: add one or more tag IDs.
+- `linkGoalAction` or `linkSavingsGoalAction`: link matched transactions to a goal.
+- `needsReviewByUserAction` or `unassignNeedsReviewByUserAction`: set or clear a review assignee.
+- `sendNotificationAction`: send a notification when the rule matches.
+- `setHideFromReportsAction`: hide matched transactions from reports.
+- `setLinkToPaydownBudgetAction`: link matched transactions to a paydown budget.
+- `reviewStatusAction`: set the review status.
+- `actionSetOwner`, `actionSetOwnerIsJoint`, `actionSetBusinessEntity`, and `actionSetBusinessEntityIsUnassigned`: set owner or business metadata.
+- `splitTransactionsAction`: split matched transactions with `amountType` and `splitsInfo`.
+
+Use `applyToExistingTransactions: False` when creating or testing a rule that should only affect future transactions. Set it to `True` only when you intentionally want Monarch to apply the rule to existing matching transactions.
+
+`update_transaction_rule(rule_id, rule)` adds the `id` field for you. For ordering, `update_transaction_rule_order(rule_id, order)` moves a rule to a zero-based position and returns the reordered rule list.
+
+`delete_all_transaction_rules()` is intentionally exposed for parity with Monarch's web app, but it deletes every configured transaction rule in the account. Prefer `delete_transaction_rule(rule_id)` for normal automation.
 
 ## Typed Client
 

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -38,6 +38,163 @@ MONARCH_COOKIE_HEADERS = {
     "monarch-client-version": "2025.05",
 }
 
+TRANSACTION_RULE_FIELDS_FRAGMENT = """
+          fragment TransactionRuleFields on TransactionRuleV2 {
+            id
+            merchantCriteriaUseOriginalStatement
+            merchantCriteria {
+              operator
+              value
+              __typename
+            }
+            originalStatementCriteria {
+              operator
+              value
+              __typename
+            }
+            merchantNameCriteria {
+              operator
+              value
+              __typename
+            }
+            amountCriteria {
+              operator
+              isExpense
+              value
+              valueRange {
+                lower
+                upper
+                __typename
+              }
+              __typename
+            }
+            categoryIds
+            accountIds
+            categories {
+              id
+              name
+              icon
+              __typename
+            }
+            accounts {
+              id
+              displayName
+              icon
+              logoUrl
+              __typename
+            }
+            criteriaOwnerIsJoint
+            criteriaOwnerUserIds
+            criteriaOwnerUsers {
+              id
+              displayName
+              profilePictureUrl
+              __typename
+            }
+            criteriaBusinessEntityIds
+            criteriaBusinessEntityIsUnassigned
+            criteriaBusinessEntities {
+              id
+              name
+              logoUrl
+              color
+              __typename
+            }
+            setMerchantAction {
+              id
+              name
+              __typename
+            }
+            setCategoryAction {
+              id
+              name
+              icon
+              __typename
+            }
+            addTagsAction {
+              id
+              name
+              color
+              __typename
+            }
+            linkGoalAction {
+              id
+              name
+              imageStorageProvider
+              imageStorageProviderId
+              __typename
+            }
+            linkSavingsGoalAction {
+              id
+              name
+              imageStorageProvider
+              imageStorageProviderId
+              __typename
+            }
+            needsReviewByUserAction {
+              id
+              displayName
+              __typename
+            }
+            unassignNeedsReviewByUserAction
+            sendNotificationAction
+            setHideFromReportsAction
+            setLinkToPaydownBudgetAction
+            reviewStatusAction
+            actionSetOwnerIsJoint
+            actionSetOwner {
+              id
+              displayName
+              profilePictureUrl
+              __typename
+            }
+            actionSetBusinessEntity {
+              id
+              name
+              logoUrl
+              color
+              __typename
+            }
+            actionSetBusinessEntityIsUnassigned
+            recentApplicationCount
+            lastAppliedAt
+            splitTransactionsAction {
+              amountType
+              splitsInfo {
+                categoryId
+                merchantName
+                amount
+                goalId
+                savingsGoalId
+                tags
+                hideFromReports
+                reviewStatus
+                needsReviewByUserId
+                ownerUserId
+                ownerIsJoint
+                businessEntityId
+                businessEntityIsUnassigned
+                __typename
+              }
+              __typename
+            }
+            __typename
+          }
+"""
+
+PAYLOAD_ERROR_FIELDS_FRAGMENT = """
+          fragment PayloadErrorFields on PayloadError {
+            fieldErrors {
+              field
+              messages
+              __typename
+            }
+            message
+            code
+            __typename
+          }
+"""
+
 
 @dataclass
 class BalanceHistoryRow:
@@ -1666,6 +1823,320 @@ class MonarchMoney(object):
         return await self.gql_call(
             operation="GetTransactionsList", graphql_query=query, variables=variables
         )
+
+    async def get_transaction_rules(self) -> Dict[str, Any]:
+        """
+        Gets all transaction rules configured in the account, including their order,
+        criteria, and actions.
+        """
+        query = gql(
+            """
+          query Web_GetTransactionRules {
+            transactionRules {
+              id
+              order
+              ...TransactionRuleFields
+              __typename
+            }
+          }
+        """
+            + TRANSACTION_RULE_FIELDS_FRAGMENT
+        )
+
+        return await self.gql_call(
+            operation="Web_GetTransactionRules", graphql_query=query
+        )
+
+    async def preview_transaction_rule(
+        self, rule: Dict[str, Any], offset: Optional[int] = 0
+    ) -> Dict[str, Any]:
+        """
+        Previews the transactions that would be affected by a transaction rule.
+
+        :param rule: A dictionary matching Monarch's TransactionRulePreviewInput.
+        :param offset: The number of preview results to skip before retrieving results.
+        """
+        query = gql(
+            """
+          query Common_PreviewTransactionRule($rule: TransactionRulePreviewInput!, $offset: Int) {
+            transactionRulePreview(input: $rule) {
+              totalCount
+              results(offset: $offset, limit: 30) {
+                newName
+                newSplitTransactions
+                newCategory {
+                  id
+                  icon
+                  name
+                  __typename
+                }
+                newOwnerIsJoint
+                newOwnerUser {
+                  id
+                  displayName
+                  profilePictureUrl
+                  __typename
+                }
+                newHideFromReports
+                newTags {
+                  id
+                  name
+                  color
+                  order
+                  __typename
+                }
+                newGoal {
+                  id
+                  name
+                  imageStorageProvider
+                  imageStorageProviderId
+                  __typename
+                }
+                newSavingsGoal {
+                  id
+                  name
+                  imageStorageProvider
+                  imageStorageProviderId
+                  __typename
+                }
+                newBusinessEntity {
+                  id
+                  name
+                  logoUrl
+                  color
+                  __typename
+                }
+                newBusinessEntityIsUnassigned
+                transaction {
+                  id
+                  date
+                  amount
+                  merchant {
+                    id
+                    name
+                    __typename
+                  }
+                  category {
+                    id
+                    name
+                    icon
+                    __typename
+                  }
+                  ownedByUser {
+                    id
+                    displayName
+                    profilePictureUrl
+                    __typename
+                  }
+                  businessEntity {
+                    id
+                    name
+                    logoUrl
+                    color
+                    __typename
+                  }
+                  goal {
+                    id
+                    name
+                    imageStorageProvider
+                    imageStorageProviderId
+                    __typename
+                  }
+                  savingsGoalEvent {
+                    id
+                    goal {
+                      id
+                      name
+                      imageStorageProvider
+                      imageStorageProviderId
+                      __typename
+                    }
+                    __typename
+                  }
+                  __typename
+                }
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+        )
+
+        return await self.gql_call(
+            operation="Common_PreviewTransactionRule",
+            graphql_query=query,
+            variables={"rule": rule, "offset": offset},
+        )
+
+    async def create_transaction_rule(self, rule: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Creates a transaction rule.
+
+        :param rule: A dictionary matching Monarch's CreateTransactionRuleInput.
+        """
+        query = gql(
+            """
+          mutation Common_CreateTransactionRuleMutationV2($input: CreateTransactionRuleInput!) {
+            createTransactionRuleV2(input: $input) {
+              transactionRule {
+                id
+                order
+                ...TransactionRuleFields
+                __typename
+              }
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+            + TRANSACTION_RULE_FIELDS_FRAGMENT
+            + PAYLOAD_ERROR_FIELDS_FRAGMENT
+        )
+
+        return await self.gql_call(
+            operation="Common_CreateTransactionRuleMutationV2",
+            graphql_query=query,
+            variables={"input": rule},
+        )
+
+    async def update_transaction_rule(
+        self, rule_id: str, rule: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Updates a transaction rule.
+
+        :param rule_id: The ID of the transaction rule to update.
+        :param rule: A dictionary matching Monarch's UpdateTransactionRuleInput, without the id.
+        """
+        query = gql(
+            """
+          mutation Common_UpdateTransactionRuleMutationV2($input: UpdateTransactionRuleInput!) {
+            updateTransactionRuleV2(input: $input) {
+              transactionRule {
+                id
+                order
+                ...TransactionRuleFields
+                __typename
+              }
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+            + TRANSACTION_RULE_FIELDS_FRAGMENT
+            + PAYLOAD_ERROR_FIELDS_FRAGMENT
+        )
+
+        transaction_rule_input = {**rule, "id": rule_id}
+
+        return await self.gql_call(
+            operation="Common_UpdateTransactionRuleMutationV2",
+            graphql_query=query,
+            variables={"input": transaction_rule_input},
+        )
+
+    async def update_transaction_rule_order(
+        self, rule_id: str, order: int
+    ) -> Dict[str, Any]:
+        """
+        Updates a transaction rule's order and returns the reordered rule list.
+
+        :param rule_id: The ID of the transaction rule to move.
+        :param order: The new order value for the rule.
+        """
+        query = gql(
+            """
+          mutation Web_UpdateRuleOrderMutation($id: ID!, $order: Int!) {
+            updateTransactionRuleOrderV2(id: $id, order: $order) {
+              transactionRules {
+                id
+                order
+                ...TransactionRuleFields
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+            + TRANSACTION_RULE_FIELDS_FRAGMENT
+        )
+
+        return await self.gql_call(
+            operation="Web_UpdateRuleOrderMutation",
+            graphql_query=query,
+            variables={"id": rule_id, "order": order},
+        )
+
+    async def delete_transaction_rule(self, rule_id: str) -> bool:
+        """
+        Deletes a transaction rule.
+
+        :param rule_id: The ID of the transaction rule to delete.
+        """
+        query = gql(
+            """
+          mutation Common_DeleteTransactionRule($id: ID!) {
+            deleteTransactionRule(id: $id) {
+              deleted
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+            + PAYLOAD_ERROR_FIELDS_FRAGMENT
+        )
+
+        response = await self.gql_call(
+            operation="Common_DeleteTransactionRule",
+            graphql_query=query,
+            variables={"id": rule_id},
+        )
+
+        errors = response["deleteTransactionRule"]["errors"]
+        if errors:
+            raise RequestFailedException(errors)
+
+        return True
+
+    async def delete_all_transaction_rules(self) -> bool:
+        """
+        Deletes all transaction rules configured in the account.
+        """
+        query = gql(
+            """
+          mutation Web_DeleteAllTransactionRulesMutation {
+            deleteAllTransactionRules {
+              deleted
+              errors {
+                ...PayloadErrorFields
+                __typename
+              }
+              __typename
+            }
+          }
+        """
+            + PAYLOAD_ERROR_FIELDS_FRAGMENT
+        )
+
+        response = await self.gql_call(
+            operation="Web_DeleteAllTransactionRulesMutation",
+            graphql_query=query,
+        )
+
+        if not response["deleteAllTransactionRules"]["deleted"]:
+            raise RequestFailedException(response["deleteAllTransactionRules"]["errors"])
+
+        return True
 
     async def create_transaction(
         self,

--- a/tests/get_transaction_rules.json
+++ b/tests/get_transaction_rules.json
@@ -1,0 +1,160 @@
+{
+  "transactionRules": [
+    {
+      "id": "rule_1",
+      "order": 1,
+      "merchantCriteriaUseOriginalStatement": false,
+      "merchantCriteria": [],
+      "originalStatementCriteria": [],
+      "merchantNameCriteria": [
+        {
+          "operator": "contains",
+          "value": "Example Market",
+          "__typename": "MerchantCriterion"
+        }
+      ],
+      "amountCriteria": null,
+      "categoryIds": [],
+      "accountIds": [],
+      "categories": [],
+      "accounts": [],
+      "criteriaOwnerIsJoint": false,
+      "criteriaOwnerUserIds": [],
+      "criteriaOwnerUsers": [],
+      "criteriaBusinessEntityIds": [],
+      "criteriaBusinessEntityIsUnassigned": false,
+      "criteriaBusinessEntities": [],
+      "setMerchantAction": {
+        "id": "merchant_1",
+        "name": "Example Market",
+        "__typename": "Merchant"
+      },
+      "setCategoryAction": {
+        "id": "category_1",
+        "name": "Groceries",
+        "icon": "cart",
+        "__typename": "Category"
+      },
+      "addTagsAction": [
+        {
+          "id": "tag_1",
+          "name": "Household",
+          "color": "#19D2A5",
+          "__typename": "TransactionTag"
+        }
+      ],
+      "linkGoalAction": null,
+      "linkSavingsGoalAction": null,
+      "needsReviewByUserAction": null,
+      "unassignNeedsReviewByUserAction": false,
+      "sendNotificationAction": false,
+      "setHideFromReportsAction": false,
+      "setLinkToPaydownBudgetAction": false,
+      "reviewStatusAction": "reviewed",
+      "actionSetOwnerIsJoint": false,
+      "actionSetOwner": null,
+      "actionSetBusinessEntity": null,
+      "actionSetBusinessEntityIsUnassigned": false,
+      "recentApplicationCount": 5,
+      "lastAppliedAt": "2026-01-15T12:00:00Z",
+      "splitTransactionsAction": null,
+      "__typename": "TransactionRuleV2"
+    },
+    {
+      "id": "rule_2",
+      "order": 2,
+      "merchantCriteriaUseOriginalStatement": true,
+      "merchantCriteria": [],
+      "originalStatementCriteria": [
+        {
+          "operator": "contains",
+          "value": "EXAMPLE ONLINE",
+          "__typename": "MerchantCriterion"
+        }
+      ],
+      "merchantNameCriteria": [],
+      "amountCriteria": {
+        "operator": "between",
+        "isExpense": true,
+        "value": null,
+        "valueRange": {
+          "lower": 10.0,
+          "upper": 100.0,
+          "__typename": "DecimalRange"
+        },
+        "__typename": "AmountCriteriaV2"
+      },
+      "categoryIds": [
+        "category_2"
+      ],
+      "accountIds": [
+        "account_1"
+      ],
+      "categories": [
+        {
+          "id": "category_2",
+          "name": "Shopping",
+          "icon": "bag",
+          "__typename": "Category"
+        }
+      ],
+      "accounts": [
+        {
+          "id": "account_1",
+          "displayName": "Checking",
+          "icon": null,
+          "logoUrl": null,
+          "__typename": "Account"
+        }
+      ],
+      "criteriaOwnerIsJoint": false,
+      "criteriaOwnerUserIds": [],
+      "criteriaOwnerUsers": [],
+      "criteriaBusinessEntityIds": [],
+      "criteriaBusinessEntityIsUnassigned": false,
+      "criteriaBusinessEntities": [],
+      "setMerchantAction": null,
+      "setCategoryAction": null,
+      "addTagsAction": [],
+      "linkGoalAction": null,
+      "linkSavingsGoalAction": null,
+      "needsReviewByUserAction": null,
+      "unassignNeedsReviewByUserAction": false,
+      "sendNotificationAction": false,
+      "setHideFromReportsAction": false,
+      "setLinkToPaydownBudgetAction": false,
+      "reviewStatusAction": null,
+      "actionSetOwnerIsJoint": false,
+      "actionSetOwner": null,
+      "actionSetBusinessEntity": null,
+      "actionSetBusinessEntityIsUnassigned": false,
+      "recentApplicationCount": 0,
+      "lastAppliedAt": null,
+      "splitTransactionsAction": {
+        "amountType": "absolute",
+        "splitsInfo": [
+          {
+            "categoryId": "category_3",
+            "merchantName": "Example Online",
+            "amount": 25.0,
+            "goalId": null,
+            "savingsGoalId": null,
+            "tags": [
+              "tag_2"
+            ],
+            "hideFromReports": false,
+            "reviewStatus": "needs_review",
+            "needsReviewByUserId": null,
+            "ownerUserId": null,
+            "ownerIsJoint": false,
+            "businessEntityId": null,
+            "businessEntityIsUnassigned": false,
+            "__typename": "SplitTransactionsActionInfo"
+          }
+        ],
+        "__typename": "SplitTransactionsAction"
+      },
+      "__typename": "TransactionRuleV2"
+    }
+  ]
+}

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -257,6 +257,209 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
             "Expected needsReview filter to be True",
         )
 
+    @patch.object(Client, "execute_async")
+    async def test_get_transaction_rules(self, mock_execute_async):
+        """
+        Test the get_transaction_rules method.
+        """
+        mock_execute_async.return_value = TestMonarchMoney.loadTestData(
+            filename="get_transaction_rules.json",
+        )
+
+        result = await self.monarch_money.get_transaction_rules()
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertIn("request", kwargs)
+        self.assertNotIn("document", kwargs)
+        self.assertEqual(kwargs["operation_name"], "Web_GetTransactionRules")
+        self.assertEqual(kwargs["variable_values"], {})
+        self.assertIsNotNone(result, "Expected result to not be None")
+        self.assertEqual(len(result["transactionRules"]), 2, "Expected 2 rules")
+        self.assertEqual(result["transactionRules"][0]["order"], 1)
+        self.assertEqual(
+            result["transactionRules"][0]["merchantNameCriteria"][0]["operator"],
+            "contains",
+        )
+        self.assertEqual(
+            result["transactionRules"][0]["setCategoryAction"]["name"],
+            "Groceries",
+        )
+        self.assertEqual(
+            result["transactionRules"][1]["splitTransactionsAction"]["amountType"],
+            "absolute",
+        )
+
+    @patch.object(Client, "execute_async")
+    async def test_preview_transaction_rule(self, mock_execute_async):
+        """
+        Test the preview_transaction_rule method.
+        """
+        mock_execute_async.return_value = {
+            "transactionRulePreview": {"totalCount": 1, "results": []}
+        }
+        rule = {
+            "merchantCriteria": [
+                {"operator": "contains", "value": "Example Market"}
+            ],
+            "setCategoryAction": "category_1",
+        }
+
+        result = await self.monarch_money.preview_transaction_rule(rule, offset=30)
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(kwargs["operation_name"], "Common_PreviewTransactionRule")
+        self.assertEqual(
+            kwargs["variable_values"], {"rule": rule, "offset": 30}
+        )
+        self.assertEqual(result["transactionRulePreview"]["totalCount"], 1)
+
+    @patch.object(Client, "execute_async")
+    async def test_create_transaction_rule(self, mock_execute_async):
+        """
+        Test the create_transaction_rule method.
+        """
+        mock_execute_async.return_value = {
+            "createTransactionRuleV2": {
+                "transactionRule": {"id": "rule_1"},
+                "errors": None,
+            }
+        }
+        rule = {
+            "merchantCriteria": [
+                {"operator": "contains", "value": "Example Market"}
+            ],
+            "setCategoryAction": "category_1",
+            "applyToExistingTransactions": False,
+        }
+
+        result = await self.monarch_money.create_transaction_rule(rule)
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(
+            kwargs["operation_name"], "Common_CreateTransactionRuleMutationV2"
+        )
+        self.assertEqual(kwargs["variable_values"], {"input": rule})
+        self.assertEqual(
+            result["createTransactionRuleV2"]["transactionRule"]["id"], "rule_1"
+        )
+
+    @patch.object(Client, "execute_async")
+    async def test_update_transaction_rule(self, mock_execute_async):
+        """
+        Test the update_transaction_rule method.
+        """
+        mock_execute_async.return_value = {
+            "updateTransactionRuleV2": {
+                "transactionRule": {"id": "rule_1"},
+                "errors": None,
+            }
+        }
+        rule = {
+            "merchantCriteria": [
+                {"operator": "contains", "value": "Updated Market"}
+            ],
+            "setCategoryAction": "category_2",
+            "applyToExistingTransactions": False,
+        }
+
+        result = await self.monarch_money.update_transaction_rule("rule_1", rule)
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(
+            kwargs["operation_name"], "Common_UpdateTransactionRuleMutationV2"
+        )
+        expected_input = {
+            "merchantCriteria": [
+                {"operator": "contains", "value": "Updated Market"}
+            ],
+            "setCategoryAction": "category_2",
+            "applyToExistingTransactions": False,
+            "id": "rule_1",
+        }
+        self.assertEqual(
+            kwargs["variable_values"],
+            {"input": expected_input},
+        )
+        self.assertEqual(
+            result["updateTransactionRuleV2"]["transactionRule"]["id"], "rule_1"
+        )
+
+    @patch.object(Client, "execute_async")
+    async def test_update_transaction_rule_order(self, mock_execute_async):
+        """
+        Test the update_transaction_rule_order method.
+        """
+        mock_execute_async.return_value = {
+            "updateTransactionRuleOrderV2": {
+                "transactionRules": [{"id": "rule_1", "order": 2}]
+            }
+        }
+
+        result = await self.monarch_money.update_transaction_rule_order("rule_1", 2)
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(kwargs["operation_name"], "Web_UpdateRuleOrderMutation")
+        self.assertEqual(kwargs["variable_values"], {"id": "rule_1", "order": 2})
+        self.assertEqual(
+            result["updateTransactionRuleOrderV2"]["transactionRules"][0]["order"], 2
+        )
+
+    @patch.object(Client, "execute_async")
+    async def test_delete_transaction_rule(self, mock_execute_async):
+        """
+        Test the delete_transaction_rule method.
+        """
+        mock_execute_async.return_value = {
+            "deleteTransactionRule": {"deleted": True, "errors": None}
+        }
+
+        result = await self.monarch_money.delete_transaction_rule("rule_1")
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(kwargs["operation_name"], "Common_DeleteTransactionRule")
+        self.assertEqual(kwargs["variable_values"], {"id": "rule_1"})
+        self.assertTrue(result)
+
+    @patch.object(Client, "execute_async")
+    async def test_delete_transaction_rule_false_without_errors(self, mock_execute_async):
+        """
+        Test the delete_transaction_rule method when Monarch returns a falsey
+        deleted flag without payload errors.
+        """
+        mock_execute_async.return_value = {
+            "deleteTransactionRule": {"deleted": False, "errors": None}
+        }
+
+        result = await self.monarch_money.delete_transaction_rule("rule_1")
+
+        mock_execute_async.assert_called_once()
+        self.assertTrue(result)
+
+    @patch.object(Client, "execute_async")
+    async def test_delete_all_transaction_rules(self, mock_execute_async):
+        """
+        Test the delete_all_transaction_rules method.
+        """
+        mock_execute_async.return_value = {
+            "deleteAllTransactionRules": {"deleted": True, "errors": None}
+        }
+
+        result = await self.monarch_money.delete_all_transaction_rules()
+
+        mock_execute_async.assert_called_once()
+        kwargs = mock_execute_async.call_args.kwargs
+        self.assertEqual(
+            kwargs["operation_name"], "Web_DeleteAllTransactionRulesMutation"
+        )
+        self.assertEqual(kwargs["variable_values"], {})
+        self.assertTrue(result)
+
     @patch("builtins.input", return_value="")
     @patch("getpass.getpass", return_value="")
     async def test_interactive_login(self, _input_mock, _getpass_mock):


### PR DESCRIPTION
## Type Of Change

- [ ] Bug fix
- [x] New feature (new endpoint / method)
- [x] GraphQL endpoint/query update
- [ ] Refactor
- [x] Documentation
- [x] Tests

## Summary

Adds transaction rule support so callers can inspect and manage Monarch Money's rule engine as the system of record for transaction classification automation.

Included methods:

- `get_transaction_rules()`
- `preview_transaction_rule(rule, offset=0)`
- `create_transaction_rule(rule)`
- `update_transaction_rule(rule_id, rule)`
- `update_transaction_rule_order(rule_id, order)`
- `delete_transaction_rule(rule_id)`
- `delete_all_transaction_rules()`

## Required For New Features Or Endpoint Changes

Monarch URL:

https://api.monarch.com/graphql

Sanitized request payload examples:

```json
{
  "operationName": "Web_GetTransactionRules",
  "variables": {},
  "query": "query Web_GetTransactionRules { transactionRules { id order ...TransactionRuleFields } }"
}
```

```json
{
  "operationName": "Common_PreviewTransactionRule",
  "variables": {
    "rule": {
      "merchantCriteria": [{"operator": "contains", "value": "<redacted>"}],
      "setCategoryAction": "<category_id>"
    },
    "offset": 0
  },
  "query": "query Common_PreviewTransactionRule($rule: TransactionRulePreviewInput!, $offset: Int) { transactionRulePreview(input: $rule) { totalCount results(offset: $offset, limit: 30) { newName transaction { id } } } }"
}
```

```json
{
  "operationName": "Common_CreateTransactionRuleMutationV2",
  "variables": {
    "input": {
      "merchantCriteria": [{"operator": "contains", "value": "<redacted>"}],
      "setCategoryAction": "<category_id>",
      "applyToExistingTransactions": false
    }
  },
  "query": "mutation Common_CreateTransactionRuleMutationV2($input: CreateTransactionRuleInput!) { createTransactionRuleV2(input: $input) { transactionRule { id order ...TransactionRuleFields } errors { ...PayloadErrorFields } } }"
}
```

```json
{
  "operationName": "Common_UpdateTransactionRuleMutationV2",
  "variables": {
    "input": {
      "id": "<rule_id>",
      "merchantCriteria": [{"operator": "contains", "value": "<redacted-updated>"}],
      "setCategoryAction": "<category_id>",
      "setHideFromReportsAction": true,
      "applyToExistingTransactions": false
    }
  },
  "query": "mutation Common_UpdateTransactionRuleMutationV2($input: UpdateTransactionRuleInput!) { updateTransactionRuleV2(input: $input) { transactionRule { id order ...TransactionRuleFields } errors { ...PayloadErrorFields } } }"
}
```

```json
{
  "operationName": "Web_UpdateRuleOrderMutation",
  "variables": {
    "id": "<rule_id>",
    "order": 2
  },
  "query": "mutation Web_UpdateRuleOrderMutation($id: ID!, $order: Int!) { updateTransactionRuleOrderV2(id: $id, order: $order) { transactionRules { id order ...TransactionRuleFields } } }"
}
```

```json
{
  "operationName": "Common_DeleteTransactionRule",
  "variables": {
    "id": "<rule_id>"
  },
  "query": "mutation Common_DeleteTransactionRule($id: ID!) { deleteTransactionRule(id: $id) { deleted errors { ...PayloadErrorFields } } }"
}
```

```json
{
  "operationName": "Web_DeleteAllTransactionRulesMutation",
  "variables": {},
  "query": "mutation Web_DeleteAllTransactionRulesMutation { deleteAllTransactionRules { deleted errors { ...PayloadErrorFields } } }"
}
```

Sanitized response shape:

```json
{
  "transactionRules": [
    {
      "id": "<rule_id>",
      "order": 1,
      "merchantCriteria": [
        {
          "operator": "contains",
          "value": "<redacted>"
        }
      ],
      "amountCriteria": null,
      "categoryIds": [],
      "accountIds": [],
      "setMerchantAction": {
        "id": "<merchant_id>",
        "name": "<redacted>"
      },
      "setCategoryAction": {
        "id": "<category_id>",
        "name": "<category_name>",
        "icon": "<icon>"
      },
      "addTagsAction": [],
      "reviewStatusAction": "reviewed",
      "recentApplicationCount": 0,
      "lastAppliedAt": null,
      "splitTransactionsAction": null
    }
  ]
}
```

- [x] I included the Monarch URL where these requests occur
- [x] I included sanitized request payload examples
- [x] I redacted any personal or financial data

## README Update Requirement

Added `get_transaction_rules` and `preview_transaction_rule` to the Non-Mutating Methods table.

Added `create_transaction_rule`, `update_transaction_rule`, `update_transaction_rule_order`, `delete_transaction_rule`, and `delete_all_transaction_rules` to the Mutating Methods table.

Added a Transaction Rules README section with create/update/order/delete examples, common criteria/action fields, and warnings for `applyToExistingTransactions` and `delete_all_transaction_rules`.

## Explain the Change

- Adds `MonarchMoney.get_transaction_rules()` using Monarch's `Web_GetTransactionRules` GraphQL query and ordered `TransactionRuleV2` fields.
- Adds rule preview, create, update, reorder, delete, and delete-all helpers using the matching Monarch web GraphQL operations.
- Keeps the return style as raw dictionaries, matching the rest of the client.
- Raises `RequestFailedException` when delete mutations return payload errors. The live API can return `deleted: false` while still deleting the rule, so `delete_transaction_rule` treats a no-error payload as success, matching Monarch's web app behavior.
- Adds unit coverage for all new methods and README documentation for the new public API surface.
- Documents that Monarch GraphQL introspection is disabled for non-admin users and that merchant criterion values are lowercased when saved.

## Testing

- [x] `.venv/bin/python -m py_compile monarchmoney/monarchmoney.py tests/test_monarchmoney.py`
- [x] `.venv/bin/python -m unittest discover -s tests`
- [x] `.venv/bin/python setup.py check`
- [x] `.venv/bin/python smoke_rules.py --limit 1` in a separate local smoke project against a Monarch account; read-only call returned 102 rules with redacted output
- [x] `.venv/bin/python live_rule_mutation_test.py --skip-introspection` in a separate local smoke project against a Monarch account. Created a unique no-match rule, fetched it, previewed it, updated criteria and `setHideFromReportsAction`, moved it to order 0, restored its order, deleted it, and verified the account returned to 102 rules.
- [ ] `delete_all_transaction_rules` live-tested against a real Monarch account. Intentionally skipped because it deletes every configured transaction rule; covered by mocked unit tests.
