### PR TITLE
feat: surface per-transaction owner in get_transactions/get_transaction_details

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1566,6 +1566,12 @@ class MonarchMoney(object):
     
           fragment TransactionOverviewFields on Transaction {
             id
+            ownedByUser {
+              id
+              name
+              __typename
+            }
+            ownershipOverriddenAt
             amount
             pending
             date
@@ -2104,6 +2110,12 @@ class MonarchMoney(object):
           query GetTransactionDrawer($id: UUID!, $redirectPosted: Boolean) {
             getTransaction(id: $id, redirectPosted: $redirectPosted) {
               id
+              ownedByUser {
+                id
+                name
+                __typename
+              }
+              ownershipOverriddenAt
               amount
               pending
               isRecurring


### PR DESCRIPTION
## Type Of Change

- [ ] Bug fix
- [x] New feature (new endpoint / method)
- [x] GraphQL endpoint/query update
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only

This isn't a new method — it adds two existing Monarch fields to two
queries this library already sends (`GetTransactionsList` /
`get_transactions`, and `GetTransactionDrawer` / `get_transaction_details`).
Ticking both boxes above since it's a query-shape change, not a bug.

## Required For New Features Or Endpoint Changes

I don't have a browser DevTools capture for this one — the two queries
already exist unchanged in this library (Monarch's Transactions page and
transaction-detail drawer), so I didn't re-derive them. What I can offer
instead: I've run `ownedByUser`/`ownershipOverriddenAt` against the live
Monarch GraphQL API on both queries for months in a personal downstream
build (a household finance app pulling from this library), and they come
back with real, non-error data — not a schema guess. Example (synthetic
data, not a real account):

```json
{
  "id": "example-txn-id",
  "ownedByUser": { "id": "example-user-id", "name": "Jane Doe", "__typename": "User" },
  "ownershipOverriddenAt": null,
  "amount": -42.0,
  ...
}
```

`ownedByUser` is `null` until a transaction's owner has been explicitly
set (or overridden) under Monarch's couples/Shared-Views feature —
`ownershipOverriddenAt` is non-null only once someone has done that
override. Households sharing one Monarch account currently have no way
to read that per-transaction attribution back out through this library.

- [ ] I included the Monarch URL where this request occurs — N/A, see above (pre-existing query, unchanged endpoint)
- [x] I included a sanitized request payload example
- [x] I redacted any personal or financial data

## README Update Requirement (required for new features)

Not applicable — no new method, and the README doesn't enumerate
per-field response shapes for existing methods (just a one-line
description per method), so there's nothing to update there.

- [ ] I updated the README to document the new method

## Explain the Change

Adds `ownedByUser { id, name, __typename }` and `ownershipOverriddenAt`
to the `TransactionOverviewFields` fragment (used by `get_transactions`)
and the `GetTransactionDrawer` query (used by `get_transaction_details`).

Both fields already exist on Monarch's `Transaction` type — this just
selects them where the library wasn't before. Reproduce in Monarch: open
a shared/couples account, assign or view a transaction's owner in the
Transactions page or the transaction detail drawer — that's the same
data this surfaces via the API.

12-line diff, both call sites only, no unrelated formatting changes.
Full existing test suite passes locally (`pytest tests/` — 14 passed).
