### PR TITLE
Add `is_pending` flag to `get_transactions`

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1514,6 +1514,7 @@ class MonarchMoney(object):
         hidden_from_reports: Optional[bool] = None,
         is_split: Optional[bool] = None,
         is_recurring: Optional[bool] = None,
+        is_pending: Optional[bool] = None,
         imported_from_mint: Optional[bool] = None,
         synced_from_institution: Optional[bool] = None,
         needs_review: Optional[bool] = None,
@@ -1537,6 +1538,7 @@ class MonarchMoney(object):
         :param hidden_from_reports: a bool to filter for whether the transactions are hidden from reports.
         :param is_split: a bool to filter for whether the transactions are split.
         :param is_recurring: a bool to filter for whether the transactions are recurring.
+        :param is_pending: a bool to filter for whether the transactions are pending.
         :param imported_from_mint: a bool to filter for whether the transactions were imported from mint.
         :param synced_from_institution: a bool to filter for whether the transactions were synced from an institution.
         :param needs_review: a bool to filter for whether the transactions need review.
@@ -1563,7 +1565,7 @@ class MonarchMoney(object):
               __typename
             }
           }
-    
+
           fragment TransactionOverviewFields on Transaction {
             id
             amount
@@ -1642,6 +1644,9 @@ class MonarchMoney(object):
 
         if is_split is not None:
             variables["filters"]["isSplit"] = is_split
+
+        if is_pending is not None:
+            variables["filters"]["isPending"] = is_pending
 
         if imported_from_mint is not None:
             variables["filters"]["importedFromMint"] = imported_from_mint
@@ -1744,7 +1749,7 @@ class MonarchMoney(object):
               __typename
             }
           }
-  
+
           fragment PayloadErrorFields on PayloadError {
             fieldErrors {
               field


### PR DESCRIPTION
## Type Of Change

- [ ] Bug fix
- [ ] New feature (new endpoint / method)
- [x] GraphQL endpoint/query update
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only


## Required For New Features Or Endpoint Changes

If this PR adds or changes a Monarch endpoint or method, you must provide enough detail for the endpoint to be reproduced locally using browser DevTools.

Provide:

• The Monarch URL where the request occurs  
• The request payload from the browser (sanitized)  
• Any required headers if relevant (sanitized)  

Do NOT include real financial or personal data.

The PR will not be approved if this information is missing.

- [x] I included the Monarch URL where this request occurs
- [x] I included a sanitized request payload example
- [x] I redacted any personal or financial data


## README Update Requirement (required for new features)

If this PR adds a new endpoint or method (example: `get_accounts()`), you must include a commit updating the README with:

• method name  
• parameters  
• example usage  

- [ ] I updated the README to document the new method


## Explain the Change

This adds an `is_pending` parameter to the already existing `get_transactions` endpoint. You can see this in the [Transactions view in Monarch](https://app.monarch.com/transactions) when filtering as an option under "Other":

<img width="1328" height="888" alt="image" src="https://github.com/user-attachments/assets/f792808e-25b0-402a-9c4d-4ef3aa262338" />


It just updates the `filters` object accordingly.

<img width="1402" height="516" alt="image" src="https://github.com/user-attachments/assets/db27d2af-7d82-4f3f-9a77-378d9db9d0ba" />

