### PR TITLE
Fix: aiohttp sessions ignore HTTP_PROXY/HTTPS_PROXY, breaking proxied networks

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -236,7 +236,9 @@ class MonarchMoney(object):
             cookies = None
             for key in list(MONARCH_COOKIE_HEADERS) + ["X-Csrftoken"]:
                 headers.pop(key, None)
-        async with ClientSession(headers=headers, cookies=cookies) as session:
+        async with ClientSession(
+            headers=headers, cookies=cookies, trust_env=True
+        ) as session:
             resp = await session.post(url, data=data)
             if resp.status != 200:
                 raise RequestFailedException(f"HTTP Code {resp.status}: {resp.reason}")

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -3810,7 +3810,7 @@ class MonarchMoney(object):
         if mfa_secret_key:
             data["totp"] = oathtool.generate_otp(mfa_secret_key)
 
-        async with ClientSession(headers=self._headers) as session:
+        async with ClientSession(headers=self._headers, trust_env=True) as session:
             async with session.post(
                 MonarchMoneyEndpoints.getLoginEndpoint(), json=data
             ) as resp:
@@ -3887,7 +3887,7 @@ class MonarchMoney(object):
             "username": email,
         }
 
-        async with ClientSession(headers=self._headers) as session:
+        async with ClientSession(headers=self._headers, trust_env=True) as session:
             async with session.post(
                 MonarchMoneyEndpoints.getLoginEndpoint(), json=data
             ) as resp:
@@ -3961,6 +3961,7 @@ class MonarchMoney(object):
             cookies=cookies,
             timeout=self._timeout,
             ssl=True,
+            client_session_args={"trust_env": True},
         )
         return Client(
             transport=transport,


### PR DESCRIPTION
\`_login_user()\`, \`_multi_factor_authenticate()\`, and \`_get_graphql_client()\` construct \`aiohttp\` clients without \`trust_env=True\`. Unlike \`requests\`, \`aiohttp\` doesn't read \`HTTP_PROXY\`/\`HTTPS_PROXY\` env vars unless \`trust_env\` is explicitly set, so every request attempts a direct connection — silently failing on any network that requires a proxy for outbound HTTPS (e.g. behind a corporate VPN).

This adds \`trust_env=True\` to all three call sites. It's a no-op when no proxy is configured, so it shouldn't change behavior for anyone not behind one.

**Evidence:** tested against a live Monarch account on a network behind a corporate proxy. Before this change, every call from \`monarch-mcp-jamiew\` (which depends on this package) failed with a generic connection error. After applying this exact 3-line change, \`get_accounts()\` succeeded immediately — returned 63 accounts, no other changes made, no retries needed.