### PR TITLE
Add businessEntity field to transaction queries

### DIFF
--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -990,6 +990,11 @@ class MonarchMoney(object):
                 transactionsCount
                 __typename
               }
+              businessEntity {
+                id
+                name
+                __typename
+              }
               tags {
                 id
                 name
@@ -1493,6 +1498,11 @@ class MonarchMoney(object):
             account {
               id
               displayName
+              __typename
+            }
+            businessEntity {
+              id
+              name
               __typename
             }
             tags {


### PR DESCRIPTION
## Summary
- `get_transactions()` doesn't return the `businessEntity` field, even though every transaction can be assigned one (Household, or a custom business/LLC) in the Monarch web UI's "Business" field on a transaction.
- Adds `businessEntity { id name } to both `TransactionOverviewFields` fragment occurrences, matching the existing shape used for `merchant`, `account`, and `category`.

## Verification
Introspection is disabled for non-admin API users, so I confirmed the field name by testing it directly against the live API rather than reading the schema. Ran the patched query against real transaction data and got correctly populated `businessEntity: { id, name }` objects on transactions with a business assigned, and `businessEntity: null` on transactions with none assigned.

## Not included
I did not add server-side filtering by business entity. I tried a few reasonable filter key guesses (`businesses`, `businessEntityIds`, `businessIds`) against `TransactionFilterInput` and all three failed with a generic server error rather than a clear invalid-field message, so I couldn't confirm the right shape without risking submitting something broken. Reading the field (this PR) is enough to group/filter client-side in the meantime. Happy to follow up if someone with schema access can confirm the filter key.