### PR TITLE
Add household member lookup and transaction owner updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ As of writing this README, the following methods are supported:
       <td>all category groups configured in the account</td>
     </tr>
     <tr>
+      <td><code>get_household_members</code></td>
+      <td>gets household member IDs, names, display names, and roles</td>
+    </tr>
+    <tr>
       <td><code>get_transaction_details</code></td>
       <td>gets detailed transaction data for a single transaction</td>
     </tr>

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -2648,6 +2648,7 @@ class MonarchMoney(object):
         needs_review: Optional[bool] = None,
         reviewed: Optional[bool] = None,
         notes: Optional[str] = None,
+        owner_user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Updates a single existing transaction as identified by the transaction_id
@@ -2683,6 +2684,8 @@ class MonarchMoney(object):
             status from a transaction, use needs_review=True.
         - notes: This parameter is only needed when the user wants to change
             the existing note.  An empty string can be passed to clear out existing notes.
+        - owner_user_id: Member ID from get_household_members() to assign as owner.
+            An empty string sets ownership to Shared. None leaves ownership unchanged.
 
         Examples:
         - To update a note: mm.update_transaction(
@@ -2798,6 +2801,8 @@ class MonarchMoney(object):
             variables["input"].update({"goalId": goal_id})
         if notes is not None:
             variables["input"].update({"notes": notes})
+        if owner_user_id is not None:
+            variables["input"].update({"ownerUserId": owner_user_id or None})
 
         return await self.gql_call(
             operation="Web_TransactionDrawerUpdateTransaction",

--- a/monarchmoney/monarchmoney.py
+++ b/monarchmoney/monarchmoney.py
@@ -1507,6 +1507,32 @@ class MonarchMoney(object):
             variables=variables,
         )
 
+    async def get_household_members(self) -> Dict[str, Any]:
+        """
+        Gets household member IDs, names, display names, and roles.
+
+        Returns myHousehold.users with each member's id, name, displayName,
+        and householdRole. Pending invitations are not household members.
+        """
+        query = gql(
+            """
+          query Common_GetHouseHoldMemberSettings {
+            myHousehold {
+              users {
+                id
+                name
+                displayName
+                householdRole
+              }
+            }
+          }
+        """
+        )
+        return await self.gql_call(
+            operation="Common_GetHouseHoldMemberSettings",
+            graphql_query=query,
+        )
+
     async def get_subscription_details(self) -> Dict[str, Any]:
         """
         The type of subscription for the Monarch Money account.

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -286,6 +286,51 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(result["categoryGroups"]), 2, "Expected 2 category groups")
         self.assertEqual(len(result["goalsV2"]), 1, "Expected 1 goal")
 
+    @patch.object(Client, "execute_async")
+    async def test_get_household_members(self, mock_execute_async):
+        """
+        Test the get_household_members method.
+        """
+        mock_execute_async.return_value = {
+            "myHousehold": {
+                "users": [
+                    {
+                        "id": "user-1",
+                        "name": "Alex",
+                        "displayName": "Alex",
+                        "householdRole": "OWNER",
+                    },
+                    {
+                        "id": "user-2",
+                        "name": "Sam",
+                        "displayName": "Sam",
+                        "householdRole": "MEMBER",
+                    },
+                ]
+            }
+        }
+        result = await self.monarch_money.get_household_members()
+        mock_execute_async.assert_called_once()
+        self.assertIsNotNone(result, "Expected result to not be None")
+        users = result["myHousehold"]["users"]
+        self.assertEqual(len(users), 2, "Expected 2 household members")
+        self.assertEqual(users[0]["id"], "user-1")
+        self.assertEqual(users[0]["name"], "Alex")
+        self.assertEqual(users[0]["displayName"], "Alex")
+        self.assertEqual(users[0]["householdRole"], "OWNER")
+        self.assertEqual(users[1]["id"], "user-2")
+        self.assertEqual(users[1]["householdRole"], "MEMBER")
+
+    @patch.object(Client, "execute_async")
+    async def test_get_household_members_empty(self, mock_execute_async):
+        """
+        Test the get_household_members method with no members.
+        """
+        mock_execute_async.return_value = {"myHousehold": {"users": []}}
+        result = await self.monarch_money.get_household_members()
+        mock_execute_async.assert_called_once()
+        self.assertEqual(result["myHousehold"]["users"], [])
+
     async def test_login(self):
         """
         Test the login method with empty values for email and password.

--- a/tests/test_monarchmoney.py
+++ b/tests/test_monarchmoney.py
@@ -362,6 +362,41 @@ class TestMonarchMoney(unittest.IsolatedAsyncioTestCase):
             "Expected needsReview filter to be True",
         )
 
+    @patch.object(Client, "execute_async")
+    async def test_update_transaction_owner(self, mock_execute_async):
+        """Assign a household member or explicitly restore Shared ownership."""
+        for owner_user_id, expected in (("user-1", "user-1"), ("", None)):
+            with self.subTest(owner_user_id=owner_user_id):
+                mock_execute_async.reset_mock()
+                await self.monarch_money.update_transaction(
+                    "txn-1", owner_user_id=owner_user_id
+                )
+                mock_execute_async.assert_called_once()
+                self.assertEqual(
+                    mock_execute_async.call_args.kwargs["variable_values"]["input"],
+                    {
+                        "id": "txn-1",
+                        "category": None,
+                        "name": None,
+                        "ownerUserId": expected,
+                    },
+                )
+
+    @patch.object(Client, "execute_async")
+    async def test_update_transaction_preserves_owner(self, mock_execute_async):
+        """Omitted or None ownership must not turn a category edit into Shared."""
+        for kwargs in ({}, {"owner_user_id": None}):
+            with self.subTest(kwargs=kwargs):
+                mock_execute_async.reset_mock()
+                await self.monarch_money.update_transaction(
+                    "txn-1", category_id="cat-1", **kwargs
+                )
+                mock_execute_async.assert_called_once()
+                self.assertEqual(
+                    mock_execute_async.call_args.kwargs["variable_values"]["input"],
+                    {"id": "txn-1", "category": "cat-1", "name": None},
+                )
+
     @patch("builtins.input", return_value="")
     @patch("getpass.getpass", return_value="")
     async def test_interactive_login(self, _input_mock, _getpass_mock):


### PR DESCRIPTION
## Type Of Change

- [x] New feature (new endpoint / method)
- [x] GraphQL endpoint/query update
- [x] Documentation

## Explain the Change

Adds `get_household_members()` to retrieve household member IDs, names, display names, and roles. Adds an optional `owner_user_id` parameter to the existing `update_transaction()` method:

- A member ID assigns ownership.
- An empty string sets Shared ownership.
- Omitted or `None` leaves ownership unchanged, following the existing optional-update convention for notes and goals.

The parameter is appended to preserve positional argument compatibility. The two commits add the member lookup first, then the owner update. README changes use the existing method tables.

## Required For New Features Or Endpoint Changes

- [x] I included the Monarch URL where this request occurs
- [x] I included a sanitized request payload example
- [x] I redacted any personal or financial data

**Household members:** Open `https://app.monarch.com/settings/members` and inspect `Common_GetHouseHoldMemberSettings` in the browser Network panel. It sends `POST https://api.monarch.com/graphql` with empty variables. This method selects member IDs, names, display names, and roles:

```json
{
  "operationName": "Common_GetHouseHoldMemberSettings",
  "variables": {},
  "query": "query Common_GetHouseHoldMemberSettings { myHousehold { users { id name displayName householdRole } } }"
}
```

The response contains `myHousehold.users`. Pending invitations are separate and are not included. The query was verified with a live read-only call.

**Transaction ownership:** Open `https://app.monarch.com/transactions`, select a transaction, and use its owner selector. The existing `Web_TransactionDrawerUpdateTransaction` mutation accepts `ownerUserId` in its input. The web client's owner-selector code sends a member ID to assign ownership and `null` for Shared. Sanitized input examples:

```json
{"id": "example-transaction-id", "ownerUserId": "example-user-id"}
```

```json
{"id": "example-transaction-id", "ownerUserId": null}
```

The existing mutation document is unchanged; this patch adds the input field only when requested. Ownership input semantics were verified from the web client code; no live ownership writes were performed during testing. Requests use the existing authenticated GraphQL transport; no authentication or header changes are needed.

## README Update Requirement

- [x] I updated the README to document the new method

`get_household_members()` takes no parameters. Example usage:

```python
members = (await mm.get_household_members())["myHousehold"]["users"]
await mm.update_transaction(transaction_id, owner_user_id=members[0]["id"])
```

## Tests

- `python -m unittest tests/test_monarchmoney.py tests/test_monarchmoney_typed.py` — 20 passed.
- `black --check .` using the CI-pinned Black 24.8.0 — passed.
- `git diff --check` — passed.

Tests follow the existing unittest and mocked `Client.execute_async` patterns, covering member fixtures, an empty member list, owner assignment, Shared ownership, and preservation when the owner is omitted or `None`.

